### PR TITLE
Shrink width on Language Dropdown/Desktop

### DIFF
--- a/resources/js/components/Menu/MenuDropdown.vue
+++ b/resources/js/components/Menu/MenuDropdown.vue
@@ -22,7 +22,7 @@
         </div>
 
         <transition name="grow">
-            <div v-if="isOpen" class="absolute right-0 z-50 w-30 mt-2 origin-top-right rounded-md shadow-lg">
+            <div v-if="isOpen" class="absolute right-0 z-50 w-32 mt-2 origin-top-right rounded-md shadow-lg">
                 <div class="overflow-hidden bg-white rounded-md shadow-xs">
                     <slot></slot>
                 </div>

--- a/resources/js/components/Menu/MenuDropdown.vue
+++ b/resources/js/components/Menu/MenuDropdown.vue
@@ -22,7 +22,7 @@
         </div>
 
         <transition name="grow">
-            <div v-if="isOpen" class="absolute right-0 z-50 w-56 mt-2 origin-top-right rounded-md shadow-lg">
+            <div v-if="isOpen" class="absolute right-0 z-50 w-30 mt-2 origin-top-right rounded-md shadow-lg">
                 <div class="overflow-hidden bg-white rounded-md shadow-xs">
                     <slot></slot>
                 </div>


### PR DESCRIPTION
Narrows the language option dropdown on 992px + devices

**Screenshots:**

992px and larger
![Screen Shot 2020-09-15 at 2 06 53 PM](https://user-images.githubusercontent.com/4378273/93253716-e5a3f180-f75c-11ea-90c1-b7e7c75300ec.png)

Less than 992 px (no change)
![Screen Shot 2020-09-15 at 2 07 04 PM](https://user-images.githubusercontent.com/4378273/93253802-03715680-f75d-11ea-89c1-52b8722cb73e.png)
