### PR TITLE
Add profile picture to Account Settings page

### DIFF
--- a/resources/views/components/form/info.blade.php
+++ b/resources/views/components/form/info.blade.php
@@ -1,0 +1,5 @@
+<div class="mt-5">
+    <div class="flex flex-wrap px-5 py-2 mt-6 bg-gray-100 lg:flex-no-wrap md:px-8 text-sm text-gray-800">
+        {{ $slot }}
+    </div>
+</div>

--- a/resources/views/components/form/info.blade.php
+++ b/resources/views/components/form/info.blade.php
@@ -1,5 +1,0 @@
-<div class="mt-5">
-    <div class="flex flex-wrap px-5 py-2 mt-6 bg-gray-100 lg:flex-no-wrap md:px-8 text-sm text-gray-800">
-        {{ $slot }}
-    </div>
-</div>

--- a/resources/views/components/form/picture.blade.php
+++ b/resources/views/components/form/picture.blade.php
@@ -1,0 +1,5 @@
+<div class="mt-5">
+    <div class="flex flex-wrap px-5 pb-2 mt-6 border border-gray-300 md:px-8">
+        {{ $slot }}
+    </div>
+</div>

--- a/resources/views/profile.blade.php
+++ b/resources/views/profile.blade.php
@@ -20,10 +20,8 @@
                 <div class="flex-auto w-full my-5 lg:flex-even md:mt-8 md:mb-4 text-base">Profile</div>
                 <div class="flex flex-wrap w-full pb-2 text-base justify-center sm:justify-start">
                     <div class="md:flex-shrink-0">
-                        <img class="p-3 mx-auto rounded-full w-48" src="{{ auth()->user()->profile_picture }}" alt="{{ auth()->user()->name }}">
-                    </div>
-                    <div class="mt-4 sm:ml-6 sm:my-0 md:mt-0 md:ml-12 self-center">
-                        <a href="http://gravatar.com" class="py-2 self-center lg:text-lg button button-white border border-gray-300 font-normal">Update Profile Picture</a>
+                        <img class="p-3 mx-auto md:ml-3 rounded-full w-48" src="{{ auth()->user()->profile_picture }}" alt="{{ auth()->user()->name }}">
+                        <p class="py-2 self-center font-normal text-sm">Your current public profile picture is sourced from Gravatar. <a href="http://gravatar.com" class="py-2 underline">Change</a></p>
                     </div>
                 </div>
             </x-form.picture>

--- a/resources/views/profile.blade.php
+++ b/resources/views/profile.blade.php
@@ -16,9 +16,17 @@
 
             <x-form.heading>{{ __('Account Settings') }}</x-form.heading>
 
-            <x-form.info>
-                Profile images imported from <a href="http://gravatar.com" class="underline ml-1">Gravatar</a>.
-            </x-form.info>
+            <x-form.picture>
+                <div class="flex-auto w-full my-5 lg:flex-even md:mt-8 md:mb-4 text-base">Profile</div>
+                <div class="flex flex-wrap w-full pb-2 text-base justify-center sm:justify-start">
+                    <div class="md:flex-shrink-0">
+                        <img class="p-3 mx-auto rounded-full w-48" src="{{ auth()->user()->profile_picture }}" alt="{{ auth()->user()->name }}">
+                    </div>
+                    <div class="mt-4 sm:ml-6 sm:my-0 md:mt-0 md:ml-12 self-center">
+                        <a href="http://gravatar.com" class="py-2 self-center lg:text-lg button button-white border border-gray-300 font-normal">Update Profile Picture</a>
+                    </div>
+                </div>
+            </x-form.picture>
 
             <x-form.section>
                 <x-input.text

--- a/resources/views/profile.blade.php
+++ b/resources/views/profile.blade.php
@@ -16,6 +16,10 @@
 
             <x-form.heading>{{ __('Account Settings') }}</x-form.heading>
 
+            <x-form.info>
+                Profile images imported from <a href="http://gravatar.com" class="underline ml-1">Gravatar</a>.
+            </x-form.info>
+
             <x-form.section>
                 <x-input.text
                     name="name"


### PR DESCRIPTION
Adds a Profile picture section to the Account Settings page, following a design chat. 

**Screenshots:**
![Screen Shot 2020-09-15 at 4 57 33 PM](https://user-images.githubusercontent.com/4378273/93269829-640c8d80-f775-11ea-8687-57071bacad94.png)
![Screen Shot 2020-09-15 at 4 57 46 PM](https://user-images.githubusercontent.com/4378273/93269828-6373f700-f775-11ea-86bb-e3b2eb8b6678.png)

Also tried it with a really large image to make sure it didn't break here. 
<img width="1346" alt="Screen Shot 2020-09-15 at 5 05 01 PM" src="https://user-images.githubusercontent.com/4378273/93269973-b2ba2780-f775-11ea-90fc-f58a3a8ef0e5.png">
