### PR TITLE
ensure link to coc is accessible

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Onramp
 
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg)](code_of_conduct.md)
 [![Build Status](https://travis-ci.org/tightenco/onramp.svg?branch=main)](https://travis-ci.org/tightenco/onramp)
 
 Onramp aims to be a collection of resources presented in a way that makes it possible for folks to become Laravel programmers as easily and effectively as possible.

--- a/resources/views/chat.blade.php
+++ b/resources/views/chat.blade.php
@@ -26,7 +26,7 @@
 
             <ul class="list-disc">
                 <li class="mb-3 md:mb-4">Be kind to each other.</li>
-                <li class="mb-3 md:mb-4">Follow the <a href="https://github.com/tighten/onramp/blob/master/CODE_OF_CONDUCT.md">Code of Conduct</a>.</li>
+                <li class="mb-3 md:mb-4">Follow the <a href="https://github.com/tighten/onramp/blob/master/code_of_conduct.md">Code of Conduct</a>.</li>
                 <li class="mb-3 md:mb-4">This chat is for planning Onramp. Off-topic conversations are allowed within reason, but try to keep the focus mainly on planning Onramp.</li>
                 <li class="mb-3 md:mb-4">Coding questions are fine in this chat if they relate to your work on Onramp, but this isn't an intro-to-Laravel forum; try the <a href="https://discord.gg/mPZNm7A">Laravel Discord</a> for that.</li>
                 <li class="mb-3 md:mb-4">We're talking a lot about our learning process in this chat, and we have a diversity of backgrounds (and hopefully we'll grow in diversity). It's easy to see someone ask a question and assume you know more than them and, even in your attempt to help, suffocate them with help and advice. <strong>Assume every person in this chat knows things you don't</strong> and avoid developing a patronizing attitude toward anyone&mdash;even if it's out of kindness!</li>


### PR DESCRIPTION
This repository uses all lowercase for the markdown files but when you click the link GitHub displays a 404 because it is looking for the uppercase version of the file.