### PR TITLE
Adds a Track Overview Page

### DIFF
--- a/app/Http/Controllers/TrackController.php
+++ b/app/Http/Controllers/TrackController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Track;
 
-class TrackListController extends Controller
+class TrackController extends Controller
 {
     public function index()
     {

--- a/app/Http/Controllers/TrackListController.php
+++ b/app/Http/Controllers/TrackListController.php
@@ -4,32 +4,38 @@ namespace App\Http\Controllers;
 
 use App\Module;
 use App\Track;
+use Illuminate\Database\Eloquent\Collection;
 
 class TrackListController extends Controller
 {
     public function index()
     {
         $tracks = Track::has('modules')->with('modules')->get();
-        $modulesWithTracks = Module::with('tracks')->get();
-
-        $modules = $modulesWithTracks->sortBy('name')->reduce(function ($carry, $row) use ($tracks) {
-            $hasTracks = $tracks->reduce(function ($carry, $track) use ($row) {
-                $carry[$track->name] = $row->tracks->pluck('name')->contains($track->name);
-                return $carry;
-            }, []);
-
-            $carry[$row->name] = [
-                'module_name' => $row->name,
-                'has_tracks' => $hasTracks,
-            ];
-
-            return $carry;
-        }, []);
 
         return view('tracks', [
-            'modules' => $modules,
+            'modules' => $this->tracksForTable($tracks),
             'tracks' => $tracks,
-            'trackNames' => $tracks->pluck('name'),
         ]);
+    }
+
+    public function tracksForTable(Collection $tracks)
+    {
+        return $tracks->flatMap(function ($track) {
+            return $track->modules;
+
+            // @todo de-duplicate modules
+        })->mapWithKeys(function ($module) use ($tracks) {
+            return [$module->name => $this->moduleForTable($module, $tracks)];
+        })->sort()->toArray();
+    }
+
+    public function moduleForTable(Module $module, $tracks)
+    {
+        return  [
+            'module_name' => $module->name,
+            'has_tracks' => $tracks->mapWithKeys(function ($track) use ($module) {
+                return [$track->name => $track->modules->pluck('id')->contains($module->id)];
+            })->toArray(),
+        ];
     }
 }

--- a/app/Http/Controllers/TrackListController.php
+++ b/app/Http/Controllers/TrackListController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Module;
+use App\Track;
+
+class TrackListController extends Controller
+{
+    public function index()
+    {
+        $tracks = Track::all();
+        $modulesWithTracks = Module::with('tracks')->get();
+
+        $modules = $modulesWithTracks->reduce(function ($carry, $row) use ($tracks) {
+            $hasTracks = $tracks->reduce(function ($carry, $track) use ($row) {
+                $carry[$track->name] = $row->tracks->pluck('name')->contains($track->name);
+                return $carry;
+            }, []);
+
+            $carry[$row->name] = [
+                'module_name' => $row->name,
+                'has_tracks' => $hasTracks,
+            ];
+
+            return $carry;
+        }, []);
+
+        return view('tracks', [
+            'modules' => $modules,
+            'tracks' => $tracks->pluck('name'),
+        ]);
+    }
+}

--- a/app/Http/Controllers/TrackListController.php
+++ b/app/Http/Controllers/TrackListController.php
@@ -9,7 +9,7 @@ class TrackListController extends Controller
 {
     public function index()
     {
-        $tracks = Track::all();
+        $tracks = Track::has('modules')->get();
         $modulesWithTracks = Module::with('tracks')->get();
 
         $modules = $modulesWithTracks->reduce(function ($carry, $row) use ($tracks) {

--- a/app/Http/Controllers/TrackListController.php
+++ b/app/Http/Controllers/TrackListController.php
@@ -9,10 +9,10 @@ class TrackListController extends Controller
 {
     public function index()
     {
-        $tracks = Track::has('modules')->get();
+        $tracks = Track::has('modules')->with('modules')->get();
         $modulesWithTracks = Module::with('tracks')->get();
 
-        $modules = $modulesWithTracks->reduce(function ($carry, $row) use ($tracks) {
+        $modules = $modulesWithTracks->sortBy('name')->reduce(function ($carry, $row) use ($tracks) {
             $hasTracks = $tracks->reduce(function ($carry, $track) use ($row) {
                 $carry[$track->name] = $row->tracks->pluck('name')->contains($track->name);
                 return $carry;
@@ -28,7 +28,8 @@ class TrackListController extends Controller
 
         return view('tracks', [
             'modules' => $modules,
-            'tracks' => $tracks->pluck('name'),
+            'tracks' => $tracks,
+            'trackNames' => $tracks->pluck('name'),
         ]);
     }
 }

--- a/app/Http/Controllers/TrackListController.php
+++ b/app/Http/Controllers/TrackListController.php
@@ -2,9 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Module;
 use App\Track;
-use Illuminate\Database\Eloquent\Collection;
 
 class TrackListController extends Controller
 {
@@ -13,29 +11,8 @@ class TrackListController extends Controller
         $tracks = Track::has('modules')->with('modules')->get();
 
         return view('tracks', [
-            'modules' => $this->tracksForTable($tracks),
             'tracks' => $tracks,
+            'modules' => $tracks->flatMap->modules->unique->id->sort(),
         ]);
-    }
-
-    public function tracksForTable(Collection $tracks)
-    {
-        return $tracks->flatMap(function ($track) {
-            return $track->modules;
-
-            // @todo de-duplicate modules
-        })->mapWithKeys(function ($module) use ($tracks) {
-            return [$module->name => $this->moduleForTable($module, $tracks)];
-        })->sort()->toArray();
-    }
-
-    public function moduleForTable(Module $module, $tracks)
-    {
-        return  [
-            'module_name' => $module->name,
-            'has_tracks' => $tracks->mapWithKeys(function ($track) use ($module) {
-                return [$track->name => $track->modules->pluck('id')->contains($module->id)];
-            })->toArray(),
-        ];
     }
 }

--- a/resources/views/partials/navigation/header.blade.php
+++ b/resources/views/partials/navigation/header.blade.php
@@ -40,6 +40,11 @@
                         href="{{ route_wlocale('glossary')}}">
                         <span>Glossary</span>
                     </a>
+                    <a
+                        class="block mx-1 text-xl font-semibold transition-colors duration-300 ease-in-out text-blue-violet hover:text-white hover:bg-indigo-700 hover:no-underline px-3 py-1 rounded @if(Route::currentRouteName() === 'tracks') bg-indigo-100 @endif"
+                        href="{{ route_wlocale('tracks')}}">
+                        <span>Tracks</span>
+                    </a>
                 </nav>
             </div>
 
@@ -113,6 +118,12 @@
                 class="block p-6 text-xl font-semibold border-t border-gray-300 text-blue-violet hover:no-underline"
                 href="{{ route_wlocale('glossary')}} ">
                 <span>Glossary</span>
+            </a>
+
+            <a
+                class="block p-6 text-xl font-semibold border-t border-gray-300 text-blue-violet hover:no-underline"
+                href="{{ route_wlocale('tracks')}} ">
+                <span>Tracks</span>
             </a>
         </template>
 

--- a/resources/views/partials/navigation/header.blade.php
+++ b/resources/views/partials/navigation/header.blade.php
@@ -30,19 +30,19 @@
             <div class="flex-1">
                 <nav class="flex items-center">
                     <a
-                        class="block mx-1 text-xl font-semibold transition-colors duration-300 ease-in-out text-blue-violet hover:text-white hover:bg-indigo-700 hover:no-underline px-3 py-1 rounded @if(Route::currentRouteName() === 'modules.index') bg-indigo-100 @endif"
+                        class="block mx-1 text-xl font-semibold transition-colors duration-300 ease-in-out text-blue-violet hover:text-white hover:bg-indigo-700 hover:no-underline px-3 py-1 rounded @if (Route::currentRouteName() === 'modules.index') bg-indigo-100 @endif"
                         href="{{ route_wlocale('modules.index') }}">
                         <span>Learn</span>
                     </a>
 
                     <a
-                        class="block mx-1 text-xl font-semibold transition-colors duration-300 ease-in-out text-blue-violet hover:text-white hover:bg-indigo-700 hover:no-underline px-3 py-1 rounded @if(Route::currentRouteName() === 'glossary') bg-indigo-100 @endif"
-                        href="{{ route_wlocale('glossary')}}">
+                        class="block mx-1 text-xl font-semibold transition-colors duration-300 ease-in-out text-blue-violet hover:text-white hover:bg-indigo-700 hover:no-underline px-3 py-1 rounded @if (Route::currentRouteName() === 'glossary') bg-indigo-100 @endif"
+                        href="{{ route_wlocale('glossary') }}">
                         <span>Glossary</span>
                     </a>
                     <a
-                        class="block mx-1 text-xl font-semibold transition-colors duration-300 ease-in-out text-blue-violet hover:text-white hover:bg-indigo-700 hover:no-underline px-3 py-1 rounded @if(Route::currentRouteName() === 'tracks') bg-indigo-100 @endif"
-                        href="{{ route_wlocale('tracks')}}">
+                        class="block mx-1 text-xl font-semibold transition-colors duration-300 ease-in-out text-blue-violet hover:text-white hover:bg-indigo-700 hover:no-underline px-3 py-1 rounded @if (Route::currentRouteName() === 'tracks') bg-indigo-100 @endif"
+                        href="{{ route_wlocale('tracks') }}">
                         <span>Tracks</span>
                     </a>
                 </nav>
@@ -116,13 +116,13 @@
 
             <a
                 class="block p-6 text-xl font-semibold border-t border-gray-300 text-blue-violet hover:no-underline"
-                href="{{ route_wlocale('glossary')}} ">
+                href="{{ route_wlocale('glossary') }} ">
                 <span>Glossary</span>
             </a>
 
             <a
                 class="block p-6 text-xl font-semibold border-t border-gray-300 text-blue-violet hover:no-underline"
-                href="{{ route_wlocale('tracks')}} ">
+                href="{{ route_wlocale('tracks') }} ">
                 <span>Tracks</span>
             </a>
         </template>

--- a/resources/views/tracks.blade.php
+++ b/resources/views/tracks.blade.php
@@ -15,13 +15,31 @@
             </picture>
         </div>
     </div>
-    <div class="py-16 fluid-container">
-        <table class="table-auto">
+    <div class="py-6 sm:py-16 fluid-container">
+
+        <div class="sm:hidden">
+            @foreach ($tracks as $track)
+                <div class="my-2 pb-8">
+                    <div class="bg-gray-100 px-4 py-2 border-b-2 font-semibold">
+                        {{ __($track->name) }}
+                    </div>
+                    <div>
+                        <div class="px-6 py-2 font-semibold">Modules:</div>
+                        @foreach ($track->modules as $module)
+                            <div class="px-6 py-2">{{ $module->name }}</div>
+                        @endforeach
+                    </div>
+                </div>
+            @endforeach
+        </div>
+
+
+        <table class="table-auto hidden sm:block">
             <thead>
                 <tr class="bg-gray-100">
                     <th class="border px-4 py-2">Module Name</th>
 
-                    @foreach ($tracks as $track)
+                    @foreach ($trackNames as $track)
                         <th class="border px-4 py-2">{{ __($track) }}</th>
                     @endforeach
 

--- a/resources/views/tracks.blade.php
+++ b/resources/views/tracks.blade.php
@@ -1,0 +1,44 @@
+@extends('layouts.app')
+
+@section('content')
+
+<div class="w-full bg-white">
+
+    <div class="py-16 fluid-container">
+
+
+    <table class="table-auto">
+        <thead>
+            <tr class="bg-gray-100">
+                <th class="border px-4 py-2">Module Name</th>
+
+                @foreach ($tracks as $track)
+                    <th class="border px-4 py-2">{{ $track }}</th>
+                @endforeach
+
+            </tr>
+        </thead>
+
+        <tbody>
+
+        @foreach ($modules as $module)
+            <tr>
+                <td class="border px-4 py-2">
+                    {{ ($module['module_name']) }}
+                </td>
+                @foreach ($module['has_tracks'] as $hasTrack)
+                    <td class="border px-4 py-2 text-center">
+                        @if ($hasTrack)
+                            <svg class="w-5 mx-auto fill-current text-green-700" viewBox="0 0 20 20"><path d="M0 11l2-2 5 5L18 3l2 2L7 18z"/></svg>
+                        @endif
+                    </td>
+                @endforeach
+            </tr>
+        @endforeach
+        </tbody>
+
+    </table>
+</div>
+
+@endsection
+

--- a/resources/views/tracks.blade.php
+++ b/resources/views/tracks.blade.php
@@ -39,10 +39,9 @@
                 <tr class="bg-gray-100">
                     <th class="border px-4 py-2">Module Name</th>
 
-                    @foreach ($trackNames as $track)
-                        <th class="border px-4 py-2">{{ __($track) }}</th>
+                    @foreach ($tracks as $track)
+                        <th class="border px-4 py-2">{{ __($track->name) }}</th>
                     @endforeach
-
                 </tr>
             </thead>
 

--- a/resources/views/tracks.blade.php
+++ b/resources/views/tracks.blade.php
@@ -46,15 +46,14 @@
             </thead>
 
             <tbody>
-
             @foreach ($modules as $module)
                 <tr>
                     <td class="border px-4 py-2">
-                        {{ __($module['module_name']) }}
+                        {{ __($module->name) }}
                     </td>
-                    @foreach ($module['has_tracks'] as $hasTrack)
+                    @foreach ($tracks as $track)
                         <td class="border px-4 py-2 text-center">
-                            @if ($hasTrack)
+                            @if ($track->modules->pluck('id')->contains($module->id))
                                 <svg class="w-5 mx-auto fill-current text-green-700" viewBox="0 0 20 20"><path d="M0 11l2-2 5 5L18 3l2 2L7 18z"/></svg>
                             @endif
                         </td>
@@ -62,10 +61,7 @@
                 </tr>
             @endforeach
             </tbody>
-
         </table>
     </div>
 </div>
-
 @endsection
-

--- a/resources/views/tracks.blade.php
+++ b/resources/views/tracks.blade.php
@@ -3,41 +3,51 @@
 @section('content')
 
 <div class="w-full bg-white">
+    <div class="py-16 overflow-hidden bg-indigo-100 lg:py-24">
+        <div class="relative fluid-container">
+            <h1 class="max-w-xl">{{ __('Tracks') }}</h1>
 
+            <picture>
+                <source media="(min-width: 1024px)" srcset="/images/shapes/double-curve-dark-large.svg">
+
+                <img class="absolute right-0 -mr-32 transform -translate-y-1/2 pointer-events-none h-670-px opacity-10 top-1/2 lg:h-1340-px lg:-mr-48 lg:opacity-100"
+                     src="/images/shapes/single-curve-dark-small.svg" alt="Onramp">
+            </picture>
+        </div>
+    </div>
     <div class="py-16 fluid-container">
+        <table class="table-auto">
+            <thead>
+                <tr class="bg-gray-100">
+                    <th class="border px-4 py-2">Module Name</th>
 
+                    @foreach ($tracks as $track)
+                        <th class="border px-4 py-2">{{ __($track) }}</th>
+                    @endforeach
 
-    <table class="table-auto">
-        <thead>
-            <tr class="bg-gray-100">
-                <th class="border px-4 py-2">Module Name</th>
+                </tr>
+            </thead>
 
-                @foreach ($tracks as $track)
-                    <th class="border px-4 py-2">{{ $track }}</th>
-                @endforeach
+            <tbody>
 
-            </tr>
-        </thead>
-
-        <tbody>
-
-        @foreach ($modules as $module)
-            <tr>
-                <td class="border px-4 py-2">
-                    {{ ($module['module_name']) }}
-                </td>
-                @foreach ($module['has_tracks'] as $hasTrack)
-                    <td class="border px-4 py-2 text-center">
-                        @if ($hasTrack)
-                            <svg class="w-5 mx-auto fill-current text-green-700" viewBox="0 0 20 20"><path d="M0 11l2-2 5 5L18 3l2 2L7 18z"/></svg>
-                        @endif
+            @foreach ($modules as $module)
+                <tr>
+                    <td class="border px-4 py-2">
+                        {{ __($module['module_name']) }}
                     </td>
-                @endforeach
-            </tr>
-        @endforeach
-        </tbody>
+                    @foreach ($module['has_tracks'] as $hasTrack)
+                        <td class="border px-4 py-2 text-center">
+                            @if ($hasTrack)
+                                <svg class="w-5 mx-auto fill-current text-green-700" viewBox="0 0 20 20"><path d="M0 11l2-2 5 5L18 3l2 2L7 18z"/></svg>
+                            @endif
+                        </td>
+                    @endforeach
+                </tr>
+            @endforeach
+            </tbody>
 
-    </table>
+        </table>
+    </div>
 </div>
 
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ Route::group(['prefix' => '{locale}'], function () {
     Route::view('chat', 'chat', ['pageTitle' => 'Chat Guidelines'])->name('chat');
     Route::view('dev', 'dev')->name('dev');
     Route::get('glossary', 'GlossaryController@index')->name('glossary');
+    Route::get('tracks', 'TrackListController@index')->name('tracks');
 
     Route::group(['prefix' => 'modules', 'as' => 'modules.'], function () {
         Route::get('/', 'ModuleController@index')->name('index');

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,7 +10,7 @@ Route::group(['prefix' => '{locale}'], function () {
     Route::view('chat', 'chat', ['pageTitle' => 'Chat Guidelines'])->name('chat');
     Route::view('dev', 'dev')->name('dev');
     Route::get('glossary', 'GlossaryController@index')->name('glossary');
-    Route::get('tracks', 'TrackListController@index')->name('tracks');
+    Route::get('tracks', 'TrackController@index')->name('tracks');
 
     Route::group(['prefix' => 'modules', 'as' => 'modules.'], function () {
         Route::get('/', 'ModuleController@index')->name('index');

--- a/tests/Feature/TrackListTest.php
+++ b/tests/Feature/TrackListTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Module;
+use App\Track;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TrackListTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    function anyone_can_access_the_tracks_page()
+    {
+        $track = factory(Track::class)->create();
+        $module = factory(Module::class)->create();
+        $track->modules()->save($module);
+
+        $response = $this->get(route('tracks', ['locale' => 'en']));
+
+        $response->assertOk()
+            ->assertSee($track->name)
+            ->assertSee($module->name)
+            ->assertSee('svg');
+    }
+
+    /** @test */
+    function doesnt_show_tracks_with_no_modules()
+    {
+        $track = factory(Track::class)->create();
+        $response = $this->get(route('tracks', ['locale' => 'en']));
+
+        $response->assertOk()
+            ->assertDontSee($track->name);
+    }
+}

--- a/tests/Feature/TrackListTest.php
+++ b/tests/Feature/TrackListTest.php
@@ -27,7 +27,7 @@ class TrackListTest extends TestCase
     }
 
     /** @test */
-    function doesnt_show_tracks_with_no_modules()
+    function it_doesnt_show_tracks_with_no_modules()
     {
         $track = factory(Track::class)->create();
         $response = $this->get(route('tracks', ['locale' => 'en']));


### PR DESCRIPTION
Adds an additional page that displays Modules and their corresponding Tracks. 

The table format doesn't work great for small screens, especially considering we may have even more Tracks in the future. Let me know what you think about the solution I put together below, @mattstauffer. You may have better ideas on how we could handle that.  

**Screenshots**
![Screen Shot 2020-09-21 at 3 20 26 PM](https://user-images.githubusercontent.com/4378273/93817136-1fbe3900-fc1e-11ea-9091-638f5a5c9a5b.png)



![Screen Shot 2020-09-21 at 3 20 38 PM](https://user-images.githubusercontent.com/4378273/93817135-1fbe3900-fc1e-11ea-8b24-d5111642be88.png)



<img width="1025" alt="Screen Shot 2020-09-21 at 3 20 59 PM" src="https://user-images.githubusercontent.com/4378273/93817134-1f25a280-fc1e-11ea-804f-3780ae1c588a.png">

