### PR TITLE
Add "back-to-top" Button

### DIFF
--- a/resources/views/components/hero.blade.php
+++ b/resources/views/components/hero.blade.php
@@ -1,4 +1,4 @@
-<section class="grid w-full grid-cols-1 pt-12 pb-8 overflow-x-hidden text-center text-white md:px-0 md:pb-0 sm:overflow-visible md:grid-cols-4 bg-blue-black">
+<section id="top" class="grid w-full grid-cols-1 pt-12 pb-8 overflow-x-hidden text-center text-white md:px-0 md:pb-0 sm:overflow-visible md:grid-cols-4 bg-blue-black">
 	<div class="mx-auto md:ml-0 md:place-self-start">
 		@include('partials.svg.path-sm')
 	</div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -53,6 +53,27 @@ $fullPageTitle = (isset($pageTitle) ? "{$pageTitle} | " : '') . __('Onramp to La
                     console.log(error);
                 });
         }
+
+        const isInViewport = (element) => {
+            const rect = element.getBoundingClientRect();
+            return (
+                rect.top >= 0 &&
+                rect.left >= 0 &&
+                rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+                rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+            );
+        }
+
+        window.addEventListener("scroll", () => {
+            const heroBanner = window.document.querySelector('#top');
+            const topButton = window.document.querySelector('#top-button');
+
+            if (heroBanner) {
+                isInViewport(heroBanner)
+                    ? topButton.classList.add("invisible")
+                    : topButton.classList.remove("invisible");
+            }
+        });
     </script>
 
     <title>{{ $fullPageTitle }}</title>

--- a/resources/views/partials/navigation/footer.blade.php
+++ b/resources/views/partials/navigation/footer.blade.php
@@ -1,18 +1,30 @@
 <footer class="w-full px-4 py-10 text-white bg-blue-black">
-    <div class="flex items-center justify-center mx-auto text-center">
-        <div>
-            <p class="w-full mb-4 sm:w-auto sm:mb-0 text-body">{{ __('From the lovely folks at') }} <a
-                    class="font-semibold"
-                    href="https://tighten.com/"><span class="underline">Tighten.</span></a></p>
+    <div class="flex flex-col items-center">
+        <p class="w-full mb-4 sm:w-auto sm:mb-0 text-body">
+            {{ __('From the lovely folks at') }}
 
-            <div class="text-base text-mint">
-                <a class="mr-3 underline"
-                    href="{{ route_wlocale('use-of-data') }}">{{ __('Use of Data') }}</a>
+            <a class="font-semibold" href="https://tighten.com/">
+                <span class="underline">Tighten.</span>
+            </a>
+        </p>
 
-                <a href="https://github.com/tighten/onramp"
-                    class="underline"
-                    target="_blank">{{ __('Source & Roadmap') }}</a>
-            </div>
+        <div class="text-base text-mint">
+            <a class="mr-3 underline" href="{{ route_wlocale('use-of-data') }}">
+                {{ __('Use of Data') }}
+            </a>
+
+            <a href="https://github.com/tighten/onramp" class="underline" target="_blank">
+                {{ __('Source & Roadmap') }}
+            </a>
         </div>
     </div>
+
+    <x-button.primary
+        id="top-button"
+        href="#top"
+        class="fixed flex flex-col items-center self-end invisible w-16 h-16 uppercase rounded-full bottom-10 right-48"
+    >
+        <span class="inline-block font-semibold transform -rotate-90">&gt;</span>
+        <span class="inline-block font-semibold">{{ __('Top') }}</span>
+    </x-button.primary>
 </footer>

--- a/resources/views/partials/navigation/footer.blade.php
+++ b/resources/views/partials/navigation/footer.blade.php
@@ -22,9 +22,9 @@
     <x-button.primary
         id="top-button"
         href="#top"
-        class="fixed flex flex-col items-center self-end invisible w-16 h-16 uppercase rounded-full bottom-10 right-48"
+        class="fixed invisible uppercase rounded-full bottom-10 right-48"
     >
-        <span class="inline-block font-semibold transform -rotate-90">&gt;</span>
-        <span class="inline-block font-semibold">{{ __('Top') }}</span>
+        <span class="block font-semibold text-center transform -rotate-90">&gt;</span>
+        <span class="block font-semibold text-center">{{ __('Top') }}</span>
     </x-button.primary>
 </footer>


### PR DESCRIPTION
# Summary
With the addition of this button, users will be able to navigate back to the top of the "Learn" index, glossary, and track pages during the middle of the content or if they reach the footer.
> closes #387 

### Functionality
- Button only displays if there's a hero banner on the page and the hero banner is outside the viewport
- Clicking on the button navigates your back to the top

### Options
I wanted to go with a fully rounded button, but I also wanted to utilize the `x-button.primary` component. Since the button has default padding that I couldn't workaround, I decided to go with what it gave me. If we decide to go a different route with its look, I have no problem making this a standalone element. Also, I'm okay with adjusting the position if it feels too close to the main content.

### Screenshot
![back-to-top-button](https://user-images.githubusercontent.com/6867485/168921673-302743bd-ac9d-4588-a9f7-691f3d10286f.gif)

