### PR TITLE
Add "can_expire" and "expiration_date" Columns to Resource

### DIFF
--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -31,7 +31,10 @@ class Resource extends Model implements Completable
         'id' => 'int',
         'is_bonus' => 'boolean',
         'is_free' => 'boolean',
+        'can_expire' => 'boolean',
+        'expiration_date' => 'datetime',
     ];
+
 
     public function modules()
     {

--- a/app/Nova/Resource.php
+++ b/app/Nova/Resource.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use Inspheric\Fields\Url;
 use Laravel\Nova\Fields\BelongsToMany;
 use Laravel\Nova\Fields\Boolean;
+use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Select;
 use Laravel\Nova\Fields\Text;
@@ -79,6 +80,17 @@ class Resource extends BaseResource
             Boolean::make('Is Assigned To Module', function () {
                 return $this->isAssignedToAModule();
             }),
+
+            Boolean::make('Can Expire')
+                ->hideFromIndex(),
+
+            DateTime::make('Expiration Date')
+                ->hideFromIndex(),
+
+            DateTime::make('Date Added', 'created_at')
+                ->hideFromIndex()
+                ->hideWhenCreating()
+                ->hideWhenUpdating(),
 
             BelongsToMany::make('Modules'),
         ];

--- a/database/migrations/2022_05_18_153847_add_expiration_date_and_can_expire_columns_to_resources_table.php
+++ b/database/migrations/2022_05_18_153847_add_expiration_date_and_can_expire_columns_to_resources_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddExpirationDateAndCanExpireColumnsToResourcesTable extends Migration
+{
+
+    public function up()
+    {
+        Schema::table('resources', function (Blueprint $table) {
+            $table->timestamp('expiration_date')->nullable()->after('module_id');
+            $table->boolean('can_expire')->default(false)->after('is_bonus');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('resources', function (Blueprint $table) {
+            $table->dropColumn('expiration_date');
+            $table->dropColumn('can_expire');
+        });
+    }
+}

--- a/database/migrations/2022_05_18_153847_add_expiration_date_and_can_expire_columns_to_resources_table.php
+++ b/database/migrations/2022_05_18_153847_add_expiration_date_and_can_expire_columns_to_resources_table.php
@@ -10,7 +10,7 @@ class AddExpirationDateAndCanExpireColumnsToResourcesTable extends Migration
     public function up()
     {
         Schema::table('resources', function (Blueprint $table) {
-            $table->timestamp('expiration_date')->default(now()->months(6))->after('module_id');
+            $table->timestamp('expiration_date')->default(now()->addMonths(6))->after('module_id');
             $table->boolean('can_expire')->default(true)->after('is_bonus');
         });
     }

--- a/database/migrations/2022_05_18_153847_add_expiration_date_and_can_expire_columns_to_resources_table.php
+++ b/database/migrations/2022_05_18_153847_add_expiration_date_and_can_expire_columns_to_resources_table.php
@@ -10,8 +10,8 @@ class AddExpirationDateAndCanExpireColumnsToResourcesTable extends Migration
     public function up()
     {
         Schema::table('resources', function (Blueprint $table) {
-            $table->timestamp('expiration_date')->nullable()->after('module_id');
-            $table->boolean('can_expire')->default(false)->after('is_bonus');
+            $table->timestamp('expiration_date')->default(now()->months(6))->after('module_id');
+            $table->boolean('can_expire')->default(true)->after('is_bonus');
         });
     }
 


### PR DESCRIPTION
# Summary
This pull request creates two new columns for resources to keep track of the freshness of our content. Both columns are hidden from the index but are displayed on the view and edit pages. I've also decided to show the `created_at` date on the view page so we can make a quick comparison of the content's age.
- "can_expire" defaults to true
- "expiration_date" defaults to 6 months from the moment the resource is added, but can manually be set to a specific date on creation.
> closes #391 

## Future Work
- Curate a list of aged content and notify the ops channel weekly for rectification.

## Screenshots
![Screen Shot 2022-05-18 at 11 38 03 AM](https://user-images.githubusercontent.com/6867485/169099837-570b49e8-ccea-4a6d-b301-688743817bd1.png)
![Screen Shot 2022-05-18 at 11 37 03 AM](https://user-images.githubusercontent.com/6867485/169099845-7977c023-cb75-43f9-8bc2-e165a4e522c3.png)
![Screen Shot 2022-05-18 at 11 38 26 AM](https://user-images.githubusercontent.com/6867485/169099846-84a1ff67-9d50-495d-bd27-14564e1703e3.png)


