### PR TITLE
Display "new" Tag for Newly Added Resources

### DIFF
--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -26,6 +26,7 @@ class Resource extends Model implements Completable
         self::ARTICLE_TYPE,
     ];
 
+    protected $appends = ['is_new'];
     protected $guarded = ['id'];
     protected $casts = [
         'id' => 'int',
@@ -69,6 +70,11 @@ class Resource extends Model implements Completable
             case 'all':
                 break;
         }
+    }
+
+    public function getIsNewAttribute()
+    {
+        return $this->created_at->diffInDays(now()) <= 14;
     }
 
     public function isAssignedToAModule()

--- a/resources/js/components/Modules/ModuleCard.vue
+++ b/resources/js/components/Modules/ModuleCard.vue
@@ -6,24 +6,18 @@
             class="flex flex-col w-full h-full transition-transform duration-300 transform shadow-md hover:no-underline hover:scale-95"
             :href="moduleUrl"
         >
-            <span
-                v-show="isCompleted && isUserModule"
-                class="absolute top-0 right-0 z-10 inline-flex items-center px-3 py-1 mt-3 mr-3 text-sm font-semibold bg-white rounded-full shadow-md text-east-bay"
-            >
-                Completed
-                <svg
-                    class="w-4 h-4 ml-2 fill-current text-teal"
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 30 30"
-                >
-                    <path
-                        d="M15 0c8.284 0 15 6.716 15 15 0 8.284-6.716 15-15 15-8.284 0-15-6.716-15-15C0 6.716 6.716 0 15 0zm6.44 9.44l-8.69 8.689-3.44-3.44-2.12 2.122 5.56 5.56 10.81-10.81-2.12-2.122z"
-                        fill-rule="evenodd"
-                    />
-                </svg>
-            </span>
 
             <span :class="`relative block w-full h-44 ${cardColorClass}`">
+                <div v-if="hasNewContent" :class="`h-2 ${labelColorClass}`"></div>
+                <div class="absolute top-0 right-0 z-10 flex flex-col items-end">
+                    <span
+                        v-if="hasNewContent"
+                        :class="`inline-flex items-center px-3 py-1 text-sm font-semibold text-white ${labelColorClass} rounded-bl-md`"
+                    >
+                        New Resources
+                    </span>
+                </div>
+
                 <img
                     v-show="imageExists"
                     class="absolute bottom-0 w-full h-auto max-h-full transform -translate-x-1/2 left-1/2 will-change-transform"
@@ -31,6 +25,23 @@
                     :src="`/images/modules/${imageName}.svg`"
                     @load="handleImageLoaded"
                 />
+
+                <span
+                    v-show="isCompleted && isUserModule"
+                    class="absolute bottom-0 right-0 z-10 inline-flex items-center px-3 py-1 mb-3 mr-3 text-sm font-semibold bg-white rounded-full shadow-md absolue text-east-bay"
+                >
+                    Completed
+                    <svg
+                        class="w-4 h-4 ml-2 fill-current text-teal"
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 30 30"
+                    >
+                        <path
+                            d="M15 0c8.284 0 15 6.716 15 15 0 8.284-6.716 15-15 15-8.284 0-15-6.716-15-15C0 6.716 6.716 0 15 0zm6.44 9.44l-8.69 8.689-3.44-3.44-2.12 2.122 5.56 5.56 10.81-10.81-2.12-2.122z"
+                            fill-rule="evenodd"
+                        />
+                    </svg>
+                </span>
             </span>
 
             <span class="flex-1 block p-4 bg-white">
@@ -46,7 +57,7 @@
 
                     <template v-if="!isCompleted && isUserModule">
                         <p
-                            class="pt-5 mt-5 text-sm font-semibold tracking-wider text-steel uppercase border-t border-silver"
+                            class="pt-5 mt-5 text-sm font-semibold tracking-wider uppercase border-t text-steel border-silver"
                         >
                             My progress:
                         </p>
@@ -101,6 +112,10 @@ export default {
         isCompleted: {
             type: Boolean,
             default: false
+        },
+        hasNewContent: {
+            type: Boolean,
+            default: false
         }
     },
 
@@ -135,7 +150,11 @@ export default {
                 ? this.moduleCardColors[this.level].even
                 : this.moduleCardColors[this.level].odd;
         },
-
+        labelColorClass() {
+            return this.cardIsEven
+                ? this.moduleCardColors[this.level].odd
+                : this.moduleCardColors[this.level].even;
+        },
         imageName() {
             return this.$options.filters.slug(this.item.name["en"]);
         },

--- a/resources/js/components/Modules/ModuleListing.vue
+++ b/resources/js/components/Modules/ModuleListing.vue
@@ -76,6 +76,7 @@
                                 "
                                 :is-user-module="userModules.includes(mod.id)"
                                 :is-completed="getModuleIsCompleted(mod)"
+                                :has-new-content="moduleHasNewResources(mod)"
                             />
                         </template>
 
@@ -100,6 +101,7 @@
                                 "
                                 :is-user-module="userModules.includes(mod.id)"
                                 :is-completed="getModuleIsCompleted(mod)"
+                                :has-new-content="moduleHasNewResources(mod)"
                             />
                         </template>
 
@@ -124,6 +126,7 @@
                                 "
                                 :is-user-module="userModules.includes(mod.id)"
                                 :is-completed="getModuleIsCompleted(mod)"
+                                :has-new-content="moduleHasNewResources(mod)"
                             />
                         </template>
 
@@ -139,6 +142,7 @@
                                 "
                                 :is-user-module="userModules.includes(mod.id)"
                                 :is-completed="getModuleIsCompleted(mod)"
+                                :has-new-content="moduleHasNewResources(mod)"
                             />
                         </template>
                     </div>
@@ -321,6 +325,9 @@ export default {
                     ? (tab.selected = true)
                     : (tab.selected = false);
             });
+        },
+        moduleHasNewResources({ resources_for_current_session }) {
+            return resources_for_current_session.filter(resource => resource.is_new).length > 0
         }
     }
 };

--- a/resources/views/partials/resource-on-module-page.blade.php
+++ b/resources/views/partials/resource-on-module-page.blade.php
@@ -10,5 +10,9 @@
         @endif
     @endauth
 
-    <a class="text-comet" href="{{ $resource->url }}" target="_blank">{{ $resource->name }}</a>
+    <a class="mr-3 text-comet" href="{{ $resource->url }}" target="_blank">{{ $resource->name }}</a>
+
+    @if($resource->is_new)
+        <span class="px-3 py-1 text-sm font-bold text-white rounded-md bg-teal">new<span>
+    @endif
 </li>

--- a/resources/views/partials/resource-on-module-page.blade.php
+++ b/resources/views/partials/resource-on-module-page.blade.php
@@ -13,6 +13,6 @@
     <a class="mr-3 text-comet" href="{{ $resource->url }}" target="_blank">{{ $resource->name }}</a>
 
     @if($resource->is_new)
-        <span class="px-3 py-1 text-sm font-bold text-white rounded-md bg-teal">new<span>
+        <span class="px-3 py-1 text-sm font-bold text-white rounded-md {{$bgColor}}">new<span>
     @endif
 </li>

--- a/tests/Unit/ResourceTest.php
+++ b/tests/Unit/ResourceTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Resource;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ResourceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    function newly_created_resources_display_new_tag()
+    {
+        $resource = Resource::factory()->create();
+        $this->assertTrue($resource->is_new);
+    }
+
+    /** @test */
+    function resources_with_a_life_span_of_exactly_two_weeks_display_new_tag()
+    {
+        $resource = Resource::factory()->create(['created_at' => now()->subDays(14)]);
+        $this->assertTrue($resource->is_new);
+    }
+
+    /** @test */
+    function resources_with_a_life_span_greater_than_two_weeks_dont_display_new_tag()
+    {
+        $resource = Resource::factory()->create(['created_at' => now()->subDays(15)]);
+        $this->assertFalse($resource->is_new);
+    }
+}


### PR DESCRIPTION
# Summary
This pull request helps the user identify which resources were newly added by displaying a "new" tag next to the resource link. The "new" label will continue to show next to its resource link for the first 14 days. Modules with newly added content also display a "new resources" tag on the module card in the index.
> closes #389 

### Screenshot
#### tags on individual resources
![Screen Shot 2022-05-18 at 1 56 28 PM](https://user-images.githubusercontent.com/6867485/169140530-e634fa4e-e54d-44d8-8674-286ad3b94a59.png)

#### label displays on module if it contains newly added resources
![Screen Shot 2022-05-23 at 2 43 20 PM](https://user-images.githubusercontent.com/6867485/169894279-3cd39d8d-ad06-4561-8be4-481d8d54b652.png)

