### PR TITLE
Add Module Link to Resources in Glossary

### DIFF
--- a/resources/views/glossary.blade.php
+++ b/resources/views/glossary.blade.php
@@ -31,10 +31,7 @@
                                     <span>{{ __('Related resources:') }}</span>
                                     @foreach ($term->resourcesForCurrentSession()->get() as $resource)
                                     <span>
-                                        {{-- @todo update this to either show first module, all modules, or none if resource unassigned --}}
-
-                                        {{-- <a href="{{ route_wlocale('modules.show', $resource->module()->first()) }}">{{ $resource->module()->first()->name }}</a>
-                                        --}}
+                                        <a href="{{ route_wlocale('modules.show', ['module' => $resource->modules()->first(), 'resourceType' => $resource->is_free ? 'free-resources' : 'paid-resources']) }}">{{ $resource->modules()->first()->name }}</a>
                                         &gt;
                                         <a href="{{ $resource->url }}">{{ $resource->name }} <img
                                                 src="/images/outbound_link_icon.svg" alt="Outbound link"
@@ -48,7 +45,7 @@
                                 <div class="flex items-center mt-4">
                                     <span class="text-steel">{{ __('Related Terms:') }}</span>
                                     @foreach ($term->relatedTerms as $relatedTerm)
-                                    <a class="px-3 ml-2 text-sm font-semibold text-steel bg-gray rounded-full"
+                                    <a class="px-3 ml-2 text-sm font-semibold rounded-full text-steel bg-gray"
                                         href="#{{ $relatedTerm->name }}">#{{ $relatedTerm->name }}</a>
                                     @endforeach
                                 </div>
@@ -58,7 +55,7 @@
                                 <div class="flex items-center mt-4">
                                     <span class="text-steel">{{ __('Related Terms:') }}</span>
                                     @foreach ($term->relatedTerms as $relatedTerm)
-                                    <a class="px-3 ml-2 text-sm font-semibold text-steel bg-gray rounded-full"
+                                    <a class="px-3 ml-2 text-sm font-semibold rounded-full text-steel bg-gray"
                                         href="#{{ $relatedTerm->name }}">#{{ $relatedTerm->name }}</a>
                                     @endforeach
                                 </div>

--- a/tests/Feature/GlossaryRelationsTest.php
+++ b/tests/Feature/GlossaryRelationsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\Module;
 use App\Models\Resource;
 use App\Models\Term;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -15,10 +16,12 @@ class GlossaryRelationsTest extends TestCase
     function glossary_page_shows_related_resources()
     {
         $currentLocale = 'en';
+        $module = Module::factory()->create();
         $resource = Resource::factory()->create(['language' => $currentLocale]);
         $otherResource = Resource::factory()->create(['language' => $currentLocale]);
         $term = Term::factory()->create();
 
+        $module->resources()->save($resource);
         $term->resources()->save($resource);
 
         $this->assertContains($resource->id, $term->fresh()->resources->pluck('id'));
@@ -32,10 +35,12 @@ class GlossaryRelationsTest extends TestCase
     function glossary_page_hides_related_resources_not_in_the_current_locale()
     {
         $currentLocale = 'en';
+        $module = Module::factory()->create();
         $englishResource = Resource::factory()->create(['language' => $currentLocale]);
         $spanishResource = Resource::factory()->create(['language' => 'es']);
         $term = Term::factory()->create();
 
+        $module->resources()->saveMany([$englishResource, $spanishResource]);
         $term->resources()->saveMany([$englishResource, $spanishResource]);
 
         $this->assertContains($englishResource->id, $term->fresh()->resources->pluck('id'));


### PR DESCRIPTION
# Summary
This pull prepends module links to their respective resources on the glossary page.
> closes #198

## Screenshot
![Screen Shot 2022-05-26 at 12 32 55 PM](https://user-images.githubusercontent.com/6867485/170560483-5e4b7360-5c27-4d1b-9441-57723236d43d.png)

