### PR TITLE
Fix Module Index

### DIFF
--- a/resources/js/components/Modules/ModuleListing.vue
+++ b/resources/js/components/Modules/ModuleListing.vue
@@ -327,6 +327,10 @@ export default {
             });
         },
         moduleHasNewResources({ resources_for_current_session }) {
+            if (!this.userLoggedIn) {
+                return false;
+            }
+
             return resources_for_current_session.filter(resource => resource.is_new).length > 0
         }
     }


### PR DESCRIPTION
# Summary
The module listing component wasn't loading due to an error within the component firing when the Vue component mounted. This change fixes the error.
> closes #412 

# Screenshot
![Screen Shot 2022-05-31 at 9 24 53 AM](https://user-images.githubusercontent.com/6867485/171197329-8bb19702-0bdf-4cbe-bade-4de7159170dd.png)
