### PR TITLE
Fix guest menu buttons

### DIFF
--- a/resources/views/partials/language-switcher.blade.php
+++ b/resources/views/partials/language-switcher.blade.php
@@ -1,5 +1,5 @@
 <div>
-    <div x-data="{isOpen: false, language: window.language, languages: window.locales}" @click.away="isOpen = false" class="relative hidden text-left lg:block">
+    <div x-data="{isOpen: false, language: window.language, languages: window.locales}" @click.away="isOpen = false" class="relative hidden text-left xl:block">
         <div>
             <button type="button" class="inline-flex items-center justify-center w-full h-12 text-base font-semibold text-white transition-colors duration-300 ease-in-out focus:outline-none focus:border-white hover:text-mint" @click="isOpen = !isOpen">
                 <span x-text="language"></span>
@@ -29,10 +29,10 @@
         </div>
     </div>
 
-    <div x-data="{isOpen: false, language: window.language, languages: window.locales}" class="relative z-50 mb-6 lg:hidden">
+    <div x-data="{isOpen: false, language: window.language, languages: window.locales}" class="relative z-50 mb-6 xl:hidden">
         <button x-show="isOpen" x-on:click="isOpen = false" tabindex="-1" class="fixed inset-0 hidden w-full h-full cursor-default" aria-label="close language switcher"></button>
 
-        <div class="px-6 py-3 lg:p-0">
+        <div class="px-6 py-3 xl:p-0">
             <label for="language-switcher" class="flex items-center -ml-2 text-white focus:outline-none ">
                 <button x-text="language" x-on:click="isOpen = !isOpen" id="alpine-language-switcher" tabindex="1" class="mr-3 font-bold text-body focus:outline-none focus:border-white">
                 </button>
@@ -43,7 +43,7 @@
             </label>
         </div>
 
-        <div x-show="isOpen" x-on:click.away="isOpen = false" class="overflow-hidden bg-steel lg:absolute lg:mt-12 lg:shadow-xl lg:left-0 lg:top-0"
+        <div x-show="isOpen" x-on:click.away="isOpen = false" class="overflow-hidden bg-steel xl:absolute xl:mt-12 xl:shadow-xl xl:left-0 xl:top-0"
             x-transition:enter="transition-all ease-in duration-200 origin-top"
             x-transition:enter-start="opacity-0 transform scale-y-0"
             x-transition:enter-end="opacity-100 transform scale-y-100"

--- a/resources/views/partials/navigation/header/desktop-header.blade.php
+++ b/resources/views/partials/navigation/header/desktop-header.blade.php
@@ -4,12 +4,12 @@
     </template>
 </sitewide-banner-->
 
-<div class="container items-center hidden lg:flex">
+<div class="container items-center hidden xl:flex">
     <a href="{{ route_wlocale('welcome') }}" class="ml-4">
         @include('partials.svg.logo-nav')
     </a>
 
-    <div class="items-center justify-between flex-1 hidden pl-12 lg:flex">
+    <div class="items-center justify-between flex-1 hidden pl-12 xl:flex">
         <div class="flex-1">
             <nav class="flex items-center">
                 @include('partials.navigation.header.main-nav')

--- a/resources/views/partials/navigation/header/guest-menu.blade.php
+++ b/resources/views/partials/navigation/header/guest-menu.blade.php
@@ -1,11 +1,11 @@
 <div class="flex w-full">
-    <a class="flex-1 inline-block w-1/2 px-4 py-1 mr-4 text-lg font-semibold text-center transition duration-200 ease-in-out bg-transparent border-2 hover:no-underline rounded-3xl text-mint border-mint hover:bg-mint hover:text-blue-black"
+    <a class="flex-1 inline-block w-auto px-4 py-1 mr-4 text-lg font-semibold text-center transition duration-200 ease-in-out bg-transparent border-2 hover:no-underline rounded-3xl text-mint border-mint hover:bg-mint hover:text-blue-black whitespace-nowrap"
         href="{{ route_wlocale('login') }}">
         <span>{{ __('Log in') }}</span>
     </a>
 
     @if (Route::has('register'))
-        <a class="flex-1 inline-block w-1/2 px-4 py-1 text-lg font-semibold text-center transition duration-200 ease-in-out border-2 under rounded-3xl border-mint bg-mint hover:no-underline hover:bg-transparent hover:text-mint"
+        <a class="flex-1 inline-block w-auto px-4 py-1 text-lg font-semibold text-center transition duration-200 ease-in-out border-2 under rounded-3xl border-mint bg-mint hover:no-underline hover:bg-transparent hover:text-mint whitespace-nowrap"
             href="{{ route_wlocale('register') }}">
             <span>{{ __('Register') }}</span>
         </a>

--- a/resources/views/partials/navigation/header/mobile-header.blade.php
+++ b/resources/views/partials/navigation/header/mobile-header.blade.php
@@ -1,5 +1,5 @@
 <div x-data="{isMenuOpen: false, toggle() { this.isMenuOpen = !this.isMenuOpen}}"
-    class="relative px-4 lg:hidden"
+    class="relative px-4 xl:hidden"
     x-cloak
     v-pre>
     <div class="flex items-center justify-between w-full">
@@ -34,7 +34,7 @@
 
         <div>
             @auth
-                <a class="block px-3 py-4 mx-1 font-bold transition-colors duration-300 ease-in-out border-t border-silver lg:border-none text-body lg:py-1 text-mint hover:text-white hover:no-underline"
+                <a class="block px-3 py-4 mx-1 font-bold transition-colors duration-300 ease-in-out border-t border-silver xl:border-none text-body xl:py-1 text-mint hover:text-white hover:no-underline"
                     href="{{ url_wlocale('preferences') }}">
                     <span>{{ __('Preferences') }}</span>
                 </a>

--- a/resources/views/partials/navigation/header/mobile-header.blade.php
+++ b/resources/views/partials/navigation/header/mobile-header.blade.php
@@ -47,18 +47,20 @@
             @guest
                 @include('partials.navigation.header.guest-menu')
             @endguest
-            <a href="{{ route_wlocale('logout') }}"
-                class="block w-full px-4 py-1 mx-auto text-lg font-semibold text-center transition duration-200 ease-in-out bg-transparent border-2 hover:no-underline rounded-3xl text-mint border-mint hover:bg-mint hover:text-blue-black"
-                onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
-                <span>{{ __('Log out') }}</span>
-            </a>
 
-            <form id="logout-form"
-                action="{{ route_wlocale('logout') }}"
-                method="POST"
-                class="hidden">
-                {{ csrf_field() }}
-            </form>
+            @auth
+                <a href="{{ route_wlocale('logout') }}"
+                    class="block w-full px-4 py-1 mx-auto text-lg font-semibold text-center transition duration-200 ease-in-out bg-transparent border-2 hover:no-underline rounded-3xl text-mint border-mint hover:bg-mint hover:text-blue-black"
+                    onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
+                    <span>{{ __('Log out') }}</span>
+                </a>
+                <form id="logout-form"
+                    action="{{ route_wlocale('logout') }}"
+                    method="POST"
+                    class="hidden">
+                    {{ csrf_field() }}
+                </form>
+            @endauth
         </div>
         <div class="fixed z-[-2] top-0 left-0 opacity-70 flex items-center justify-center w-full inset-0  bg-black"
             x-show="isMenuOpen"></div>


### PR DESCRIPTION
## Summary

This PR resolves #397. Ensures the guest menu buttons display appropriately when the language switcher is changed.

This PR also:
- changes the breakpoint for when the desktop and mobile headers are swapped from `lg` to `xl`. At the `lg` breakpoint, there was not enough room to display the guest menu in the header after the language was changed:
<img width="993" alt="Screen Shot 2022-08-05 at 10 27 41 AM" src="https://user-images.githubusercontent.com/8689444/183110774-75b1c574-1afe-4970-a6b4-eec218b28633.png">

- fixes a bug where the logout button was being displayed in the guest menu on mobile
- implements style updates to ensure the button text on the guest menu items do not wrap to a new line

| Before | After |
| - | - |
| <img width="659" alt="image" src="https://user-images.githubusercontent.com/8689444/183111200-48781fce-d2b1-474b-9735-2a6762424521.png"> | <img width="569" alt="Screen Shot 2022-08-05 at 10 23 17 AM" src="https://user-images.githubusercontent.com/8689444/183111064-ea16afc1-42b1-4052-b799-aed992578533.png"> |


