### PR TITLE
[Feature] Notify Tighten When Resources Expire

### DIFF
--- a/app/Console/Commands/GetExpiredResources.php
+++ b/app/Console/Commands/GetExpiredResources.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use App\Models\Resource;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Event;
 
 class GetExpiredResources extends Command
 {
@@ -26,6 +27,7 @@ class GetExpiredResources extends Command
         }
 
         if ($this->option('notify')) {
+            Event::dispatch('send-expired-resources', [$expiredResources]);
             return;
         }
 

--- a/app/Console/Commands/GetExpiredResources.php
+++ b/app/Console/Commands/GetExpiredResources.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Resource;
+use Illuminate\Console\Command;
+
+class GetExpiredResources extends Command
+{
+    protected $signature = 'resources:expired {--N|notify}';
+
+    protected $description = 'List or notify Tighten of expired resources.';
+
+    public function handle()
+    {
+        $expiredResources = Resource::expired()->get([
+                'name',
+                'url',
+                'expiration_date',
+                'created_at',
+            ]);
+
+        if (! count($expiredResources)) {
+            $this->info('All resources are up to date!');
+            return;
+        }
+
+        if ($this->option('notify')) {
+            return;
+        }
+
+        $this->table(
+            ['Resource Name', 'URL', 'Expired On', 'Created On'],
+            $expiredResources->each->setAppends([])->toArray(),
+        );
+    }
+}

--- a/app/Console/Commands/GetExpiredResources.php
+++ b/app/Console/Commands/GetExpiredResources.php
@@ -17,11 +17,13 @@ class GetExpiredResources extends Command
         $expiredResources = Resource::expired()
             ->orWhere(function ($query) {
                 $query->expiring();
-            })->get([
+            })
+            ->with('modules')
+            ->get([
                 'name',
                 'url',
-                'created_at',
                 'expiration_date',
+                'created_at',
             ]);
 
         if (! count($expiredResources)) {
@@ -38,7 +40,7 @@ class GetExpiredResources extends Command
             ['Resource Name', 'URL', 'Days Til Expired'],
             $expiredResources->each
                 ->setAppends(['days_til_expired'])
-                ->makeHidden(['created_at', 'expiration_date'])
+                ->makeHidden(['modules', 'created_at', 'expiration_date'])
                 ->toArray(),
         );
     }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -21,6 +21,9 @@ class Kernel extends ConsoleKernel
     {
         // $schedule->command('inspire')
         //          ->hourly();
+
+        $schedule->command('resource:expired -N')
+            ->weeklyOn(Schedule::FRIDAY, '06:00');
     }
 
     /**

--- a/app/Handlers/Events/SlackSubscriber.php
+++ b/app/Handlers/Events/SlackSubscriber.php
@@ -2,6 +2,7 @@
 
 namespace App\Handlers\Events;
 
+use App\Notifications\SendExpiredResources;
 use App\Notifications\SuggestedResourceSubmitted;
 use App\Notifications\UserSignedUp;
 use App\TightenSlack;
@@ -25,6 +26,8 @@ class SlackSubscriber
         $events->listen('new-signup', [$this, 'onNewSignup']);
 
         $events->listen('new-suggested-resource', [$this, 'onNewSuggestedResource']);
+
+        $events->listen('send-expired-resources', [$this, 'onExpiredResources']);
     }
 
     public function onNewSignup($user, $request)
@@ -35,5 +38,10 @@ class SlackSubscriber
     public function onNewSuggestedResource($suggestedResource)
     {
         $this->slack->notify(new SuggestedResourceSubmitted($suggestedResource));
+    }
+
+    public function onExpiredResources($expiredResources)
+    {
+        $this->slack->notify(new SendExpiredResources($expiredResources));
     }
 }

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -5,7 +5,6 @@ namespace App\Models;
 use App\Completable;
 use App\Facades\Preferences;
 use App\OperatingSystem;
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -13,13 +12,13 @@ class Resource extends Model implements Completable
 {
     use HasFactory;
 
-    const VIDEO_TYPE = 'video';
-    const COURSE_TYPE = 'course';
-    const AUDIO_TYPE = 'audio';
-    const BOOK_TYPE = 'book';
-    const ARTICLE_TYPE = 'article';
+    public const VIDEO_TYPE = 'video';
+    public const COURSE_TYPE = 'course';
+    public const AUDIO_TYPE = 'audio';
+    public const BOOK_TYPE = 'book';
+    public const ARTICLE_TYPE = 'article';
 
-    const TYPES = [
+    public const TYPES = [
         self::VIDEO_TYPE,
         self::COURSE_TYPE,
         self::AUDIO_TYPE,
@@ -78,7 +77,15 @@ class Resource extends Model implements Completable
 
     public function scopeExpired($query)
     {
-        return $query->where('expiration_date', '<', Carbon::now()->toDateTimeString());
+        return $query->where('expiration_date', '<', now()->toDateTimeString());
+    }
+
+    public function scopeExpiring($query)
+    {
+        return $query->whereBetween('expiration_date', [
+            now()->toDateTimeString(),
+            now()->addDays(15)->toDateTimeString(),
+        ]);
     }
 
     public function getIsNewAttribute()
@@ -86,16 +93,9 @@ class Resource extends Model implements Completable
         return $this->created_at->diffInDays(now()) <= 14;
     }
 
-    public function getDaysExpiredAttribute()
+    public function getDaysTilExpiredAttribute()
     {
-        if (! $this->isExpired()) {
-            return '0 Days';
-        }
-
-        $daysExpired = $this->expiration_date->diffInDays(now());
-        $daysLabel = $daysExpired === 1 ? ' Day' : ' Days';
-
-        return $daysExpired . $daysLabel;
+        return $this->expiration_date->diffForHumans();
     }
 
     public function isAssignedToAModule()
@@ -106,5 +106,13 @@ class Resource extends Model implements Completable
     public function isExpired()
     {
         return $this->expiration_date->isPast();
+    }
+
+    public function isExpiring()
+    {
+        return $this->expiration_date->between(
+            now()->toDateTimeString(),
+            now()->addDays(15)->toDateTimeString(),
+        );
     }
 }

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Completable;
 use App\Facades\Preferences;
 use App\OperatingSystem;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -83,5 +84,10 @@ class Resource extends Model implements Completable
     public function isAssignedToAModule()
     {
         return collect($this->modules)->isNotEmpty();
+    }
+
+    public function scopeExpired($query)
+    {
+        return $query->where('expiration_date', '<', Carbon::now()->toDateTimeString());
     }
 }

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -76,9 +76,26 @@ class Resource extends Model implements Completable
         }
     }
 
+    public function scopeExpired($query)
+    {
+        return $query->where('expiration_date', '<', Carbon::now()->toDateTimeString());
+    }
+
     public function getIsNewAttribute()
     {
         return $this->created_at->diffInDays(now()) <= 14;
+    }
+
+    public function getDaysExpiredAttribute()
+    {
+        if (! $this->isExpired()) {
+            return '0 Days';
+        }
+
+        $daysExpired = $this->expiration_date->diffInDays(now());
+        $daysLabel = $daysExpired === 1 ? ' Day' : ' Days';
+
+        return $daysExpired . $daysLabel;
     }
 
     public function isAssignedToAModule()
@@ -86,8 +103,8 @@ class Resource extends Model implements Completable
         return collect($this->modules)->isNotEmpty();
     }
 
-    public function scopeExpired($query)
+    public function isExpired()
     {
-        return $query->where('expiration_date', '<', Carbon::now()->toDateTimeString());
+        return $this->expiration_date->isPast();
     }
 }

--- a/app/Notifications/SendExpiredResources.php
+++ b/app/Notifications/SendExpiredResources.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Notifications\Messages\SlackAttachment;
+
+class SendExpiredResources extends Notification
+{
+    use Queueable;
+
+    public function __construct(protected $expiredResources)
+    {
+        //
+    }
+
+    public function via($notifiable)
+    {
+        return ['slack'];
+    }
+
+    public function toSlack($notifiable)
+    {
+        $msg = (new SlackMessage())
+                ->content('*Expired Resources Report*');
+
+        collect($this->expiredResources)->map(function ($resource) use ($msg) {
+            $msg->attachment(function (SlackAttachment $attachment) use ($resource) {
+                $attachment->fields([
+                    '*Name*' => $resource->name,
+                    '*Days Expired*' => $resource->days_expired,
+                ]);
+            });
+        });
+
+        return $msg;
+    }
+}

--- a/app/Notifications/SuggestedResourceSubmitted.php
+++ b/app/Notifications/SuggestedResourceSubmitted.php
@@ -45,9 +45,9 @@ class SuggestedResourceSubmitted extends Notification
 
     public function toSlack($notifiable)
     {
-        return (new SlackMessage)
+        return (new SlackMessage())
             ->content('New resource suggested!')
-            ->attachment(function(SlackAttachment $attachment) {
+            ->attachment(function (SlackAttachment $attachment) {
                 $attachment
                     ->title('View in Nova', url('/nova'))
                     ->fields($this->fields)

--- a/app/Notifications/SuggestedResourceSubmitted.php
+++ b/app/Notifications/SuggestedResourceSubmitted.php
@@ -46,6 +46,7 @@ class SuggestedResourceSubmitted extends Notification
     public function toSlack($notifiable)
     {
         return (new SlackMessage())
+            ->from('Onramp', ':onramp:')
             ->content('New resource suggested!')
             ->attachment(function (SlackAttachment $attachment) {
                 $attachment

--- a/app/Notifications/UserSignedUp.php
+++ b/app/Notifications/UserSignedUp.php
@@ -39,7 +39,8 @@ class UserSignedUp extends Notification
 
     public function toSlack($notifiable)
     {
-        return (new SlackMessage)
+        return (new SlackMessage())
+            ->from('Onramp', ':onramp:')
             ->attachment(function (SlackAttachment $attachment) {
                 $attachment
                     ->title('New user signup')

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "laravel/slack-notification-channel": "^2.4",
         "laravel/tinker": "^2.5",
         "laravel/ui": "^3.4",
+        "nathanheffley/laravel-slack-blocks": "^2.3",
         "spatie/laravel-translatable": "^5.2",
         "tightenco/ziggy": "^1.4"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5585120db28e259e59aaf38574d70b41",
+    "content-hash": "7fcdcb78c10e4d1f27c0ca7824ee14dc",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2267,6 +2267,66 @@
                 }
             ],
             "time": "2022-05-10T09:36:00+00:00"
+        },
+        {
+            "name": "nathanheffley/laravel-slack-blocks",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nathanheffley/laravel-slack-blocks.git",
+                "reference": "dc0795cfce554f27697e8cee3965b4b1dde956c8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nathanheffley/laravel-slack-blocks/zipball/dc0795cfce554f27697e8cee3965b4b1dde956c8",
+                "reference": "dc0795cfce554f27697e8cee3965b4b1dde956c8",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^6.0|^7.0",
+                "laravel/slack-notification-channel": "^2.0",
+                "php": "^7.1.3|^8.0"
+            },
+            "require-dev": {
+                "illuminate/notifications": "~5.8.0|^6.0|^7.0|^8.0",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^7.0|^8.0|^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "NathanHeffley\\LaravelSlackBlocks\\SlackChannelServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "NathanHeffley\\LaravelSlackBlocks\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nathan Heffley",
+                    "email": "nathan@nathanheffley.com"
+                }
+            ],
+            "description": "Slack Blocks support for laravel notifications.",
+            "keywords": [
+                "blocks",
+                "laravel",
+                "notifications",
+                "slack"
+            ],
+            "support": {
+                "issues": "https://github.com/nathanheffley/laravel-slack-blocks/issues",
+                "source": "https://github.com/nathanheffley/laravel-slack-blocks/tree/v2.3.0"
+            },
+            "time": "2020-12-01T19:20:19+00:00"
         },
         {
             "name": "nesbot/carbon",

--- a/config/database.php
+++ b/config/database.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Database\DBAL\TimestampType;
 use Illuminate\Support\Str;
 
 return [
@@ -142,6 +143,21 @@ return [
             'database' => env('REDIS_CACHE_DB', 1),
         ],
 
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Doctrine DBAL
+    |--------------------------------------------------------------------------
+    |
+    | Supports modifying certain column types in migrations.
+    |
+    */
+
+    'dbal' => [
+        'types' => [
+            'timestamp' => TimestampType::class,
+        ],
     ],
 
 ];

--- a/database/factories/ResourceFactory.php
+++ b/database/factories/ResourceFactory.php
@@ -3,8 +3,9 @@
 namespace Database\Factories;
 
 use App\Models\Module;
-use App\OperatingSystem;
 use App\Models\Resource;
+use App\OperatingSystem;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class ResourceFactory extends Factory
@@ -32,6 +33,8 @@ class ResourceFactory extends Factory
             'module_id' => Module::factory(),
             'language' => $this->faker->randomElement(['en', 'es']),
             'os' => $this->faker->randomElement(OperatingSystem::ALL),
+            'can_expire' => true,
+            'expiration_date' => Carbon::now()->addMonths(6),
         ];
     }
 }

--- a/database/factories/ResourceFactory.php
+++ b/database/factories/ResourceFactory.php
@@ -37,4 +37,39 @@ class ResourceFactory extends Factory
             'expiration_date' => Carbon::now()->addMonths(6),
         ];
     }
+
+
+    public function doesntExpire()
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'can_expire' => false,
+                'expiration_date' => null,
+            ];
+        });
+    }
+
+    public function expired()
+    {
+        Carbon::setTestNow(Carbon::today());
+
+        return $this->state(function (array $attributes) {
+            return [
+                'can_expire' => true,
+                'expiration_date' => Carbon::now()->subDays(1),
+            ];
+        });
+    }
+
+    public function expiring()
+    {
+        Carbon::setTestNow(Carbon::today());
+
+        return $this->state(function (array $attributes) {
+            return [
+                'can_expire' => true,
+                'expiration_date' => Carbon::now()->addDays(14),
+            ];
+        });
+    }
 }

--- a/database/migrations/2022_08_08_133512_update_expiration_date_column_on_resources_table.php
+++ b/database/migrations/2022_08_08_133512_update_expiration_date_column_on_resources_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('resources', function (Blueprint $table) {
+            $table->timestamp('expiration_date')
+                ->nullable()
+                ->default(now()->addMonths(6))
+                ->after('module_id')
+                ->change();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('resources', function (Blueprint $table) {
+            $table->timestamp('expiration_date')
+                ->default(now()->addMonths(6))
+                ->after('module_id')
+                ->change();
+        });
+    }
+};

--- a/tests/Feature/ResourceExpirationTest.php
+++ b/tests/Feature/ResourceExpirationTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Resource;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class ResourceExpirationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function resources_can_be_expired_or_expiring()
+    {
+        $resourceA = Resource::factory()->expired()->create();
+        $resourceB = Resource::factory()->expiring()->create();
+
+        $this->assertTrue($resourceA->isExpired());
+        $this->assertTrue($resourceB->isExpiring());
+    }
+
+    /** @test */
+    public function can_scope_expiring_and_expired_resources()
+    {
+        Resource::factory()->expired()->create();
+        Resource::factory()->expiring()->create();
+
+        $this->assertCount(2, Resource::expired()
+            ->orWhere(function ($query) {
+                $query->expiring();
+            })->get());
+    }
+
+    /** @test */
+    public function notification_is_sent_for_expired_content()
+    {
+        Notification::fake();
+        Event::fake();
+
+        Resource::factory()
+            ->count(3)
+            ->expired()
+            ->create();
+
+        Artisan::call('resource:expired -N');
+
+        Event::assertDispatched('send-expired-resources');
+    }
+
+    /** @test */
+    public function notification_is_sent_for_expiring_content()
+    {
+        Notification::fake();
+        Event::fake();
+
+        Resource::factory()
+            ->count(3)
+            ->expiring()
+            ->create();
+
+        Artisan::call('resource:expired -N');
+
+        Event::assertDispatched('send-expired-resources');
+    }
+
+    /** @test */
+    public function expired_resources_have_an_expiration_label()
+    {
+        $resourceA = Resource::factory()->expired()->create();
+        $resourceB = Resource::factory()->expiring()->create();
+
+        $this->assertSame('1 day ago', $resourceA->days_til_expired);
+        $this->assertSame('2 weeks from now', $resourceB->days_til_expired);
+    }
+}

--- a/tests/Feature/ResourceExpirationTest.php
+++ b/tests/Feature/ResourceExpirationTest.php
@@ -6,7 +6,6 @@ use App\Models\Resource;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\Notification;
 use Tests\TestCase;
 
 class ResourceExpirationTest extends TestCase
@@ -36,9 +35,8 @@ class ResourceExpirationTest extends TestCase
     }
 
     /** @test */
-    public function notification_is_sent_for_expired_content()
+    public function event_is_dispatched_for_expired_content_notification()
     {
-        Notification::fake();
         Event::fake();
 
         Resource::factory()
@@ -52,9 +50,8 @@ class ResourceExpirationTest extends TestCase
     }
 
     /** @test */
-    public function notification_is_sent_for_expiring_content()
+    public function event_is_dispatched_for_expiring_content_notification()
     {
-        Notification::fake();
         Event::fake();
 
         Resource::factory()


### PR DESCRIPTION
## Summary

This PR adds a `resource:expired --notify` command scheduled to run weekly on Fridays at 6:00AM. When there are expired resources or resources expiring within 2 weeks' time, a detailed report is sent to slack:

<img width="677" alt="image" src="https://user-images.githubusercontent.com/8689444/183704717-84ef98c4-2473-4370-992e-4243bbfe4842.png">

When the command is run without the `--notify` option, an output of expired resources are printed in the terminal:

<img width="1374" alt="image" src="https://user-images.githubusercontent.com/8689444/183705064-a0c8d45a-432d-41b0-81d1-d8cb3f6420e2.png">

### `Resource::class` Updates

- added a `days_til_expired` attribute
- added an `isExpired` and `isExpiring` helper method
- added two new query scopes: `scopeExpired` and `scopeExpiring` - the latter will return resources expiring within the next two weeks

### Other
- a new migration was added to allow resources where `can_expire` is `false` to have a nullable `expiration_date`

Resolves #406 


