### PR TITLE
Fix module resource table

### DIFF
--- a/database/factories/ResourceFactory.php
+++ b/database/factories/ResourceFactory.php
@@ -2,7 +2,6 @@
 
 namespace Database\Factories;
 
-use App\Models\Module;
 use App\Models\Resource;
 use App\OperatingSystem;
 use Carbon\Carbon;
@@ -30,7 +29,6 @@ class ResourceFactory extends Factory
             'is_free' => $this->faker->boolean,
             'is_bonus' => $this->faker->boolean(20),
             'type' => $this->faker->randomElement(Resource::TYPES),
-            'module_id' => Module::factory(),
             'language' => $this->faker->randomElement(['en', 'es']),
             'os' => $this->faker->randomElement(OperatingSystem::ALL),
             'can_expire' => true,

--- a/database/migrations/2022_08_11_113651_add_foreign_keys_to_module_resource_table.php
+++ b/database/migrations/2022_08_11_113651_add_foreign_keys_to_module_resource_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('module_resource', function (Blueprint $table) {
+            $table->foreign('module_id')->references('id')->on('modules');
+            $table->foreign('resource_id')->references('id')->on('resources');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('module_resource', function (Blueprint $table) {
+            if (DB::getDriverName() !== 'sqlite') {
+                $table->dropForeign(['module_id']);
+                $table->dropForeign(['resource_id']);    
+            }
+        });
+    }
+};

--- a/database/migrations/2022_08_11_114258_delete_module_id_column_on_resources_table.php
+++ b/database/migrations/2022_08_11_114258_delete_module_id_column_on_resources_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('resources', function (Blueprint $table) {
+            if (DB::getDriverName() !== 'sqlite') {
+                $table->dropForeign(['module_id']);
+            }
+
+            $table->dropColumn('module_id');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('resources', function (Blueprint $table) {
+            $table->unsignedBigInteger('module_id')->nullable()->after('language');
+            $table->foreign('module_id')->references('id')->on('modules');
+        });
+    }
+};


### PR DESCRIPTION
## Summary

This PR adds a migration to add foreign keys for `module_id` and `resource_id` on the `module_resource` table. It also removes the `module_id` column from the `resources` table.