### PR TITLE
Attach resources to terms via Nova

### DIFF
--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Completable;
 use App\Facades\Preferences;
+use App\Models\Term;
 use App\OperatingSystem;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -45,6 +46,11 @@ class Resource extends Model implements Completable
     public function completions()
     {
         return $this->morphMany(Completion::class, 'completable');
+    }
+
+    public function terms()
+    {
+        return $this->belongsToMany(Term::class);
     }
 
     public function scopeForCurrentSession($query)

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -50,7 +50,7 @@ class Resource extends Model implements Completable
 
     public function terms()
     {
-        return $this->belongsToMany(Term::class);
+        return $this->belongsToMany(Term::class)->withTimestamps();
     }
 
     public function scopeForCurrentSession($query)

--- a/app/Models/Term.php
+++ b/app/Models/Term.php
@@ -31,7 +31,7 @@ class Term extends Model
 
     public function resources()
     {
-        return $this->belongsToMany(Resource::class);
+        return $this->belongsToMany(Resource::class)->withTimestamps();
     }
 
     public function resourcesForCurrentSession()

--- a/app/Nova/Resource.php
+++ b/app/Nova/Resource.php
@@ -92,6 +92,8 @@ class Resource extends BaseResource
                 ->hideWhenUpdating(),
 
             BelongsToMany::make('Modules'),
+
+            BelongsToMany::make('Terms'),
         ];
     }
 

--- a/app/Nova/Term.php
+++ b/app/Nova/Term.php
@@ -3,6 +3,7 @@
 namespace App\Nova;
 
 use Illuminate\Http\Request;
+use Laravel\Nova\Fields\BelongsToMany;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Text;
 use Spatie\NovaTranslatable\Translatable;
@@ -31,7 +32,9 @@ class Term extends BaseResource
             Translatable::make([
                 Text::make('Name'),
                 Text::make('Description')->hideFromIndex(),
-            ])
+            ]),
+
+            BelongsToMany::make('Resources'),
         ];
     }
 

--- a/database/migrations/2022_08_11_170907_add_foreign_keys_to_resource_term_table.php
+++ b/database/migrations/2022_08_11_170907_add_foreign_keys_to_resource_term_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('resource_term', function (Blueprint $table) {
+            $table->foreign('resource_id')->references('id')->on('resources');
+            $table->foreign('term_id')->references('id')->on('terms');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('resource_term', function (Blueprint $table) {
+            if (DB::getDriverName() !== 'sqlite') {
+                $table->dropForeign(['resource_id']);   
+                $table->dropForeign(['term_id']);   
+            }
+        });
+    }
+};

--- a/resources/views/glossary.blade.php
+++ b/resources/views/glossary.blade.php
@@ -28,14 +28,15 @@
 
                             @if ($term->resourcesForCurrentSession->count() > 0)
                                 <div class="flex flex-col mt-4">
-                                    <span>{{ __('Related resources:') }}</span>
+                                    <span class="mb-2 font-semibold">{{ __('Related resources:') }}</span>
                                     @foreach ($term->resourcesForCurrentSession()->get() as $resource)
                                     <span>
-                                        <a href="{{ route_wlocale('modules.show', ['module' => $resource->modules()->first(), 'resourceType' => $resource->is_free ? 'free-resources' : 'paid-resources']) }}">{{ $resource->modules()->first()->name }}</a>
+                                        <a class="underline" href="{{ route_wlocale('modules.show', ['module' => $resource->modules()->first(), 'resourceType' => $resource->is_free ? 'free-resources' : 'paid-resources']) }}">{{ $resource->modules()->first()->name }}</a>
                                         &gt;
-                                        <a href="{{ $resource->url }}">{{ $resource->name }} <img
-                                                src="/images/outbound_link_icon.svg" alt="Outbound link"
-                                                class="inline w-4 align-text-top"></a>
+                                        <a class="inline-flex items-center" href="{{ $resource->url }}">
+                                            <span class="underline">{{ $resource->name }}</span>
+                                            <img src="/images/outbound_link_icon.svg" alt="Outbound link" class="inline w-4 ml-2 align-text-top">
+                                        </a>
                                     </span>
                                     @endforeach
                                 </div>


### PR DESCRIPTION
## Summary (Resolves #418)

**This PR:**

- adds the ability to attach resource to a terms via nova
- adds the ability to attach a term to a resource via nova
- adjust the style of the related resource list on the glossary page (bold heading, adds underline to links)

**Schema Changes**
- adds `withTimestamps()` to the `terms()` and `resources()` relationships
- adds a migration to add foreign keys to the `resource_term` table

### Follow Up
Once merged, we should go into Nova on production and add these relationships so that the resource lists can show on the Glossary page.

### Screenshots

<details>
<summary>Open</summary>

#### Attached Resource to Term
<img width="600" src="https://user-images.githubusercontent.com/8689444/184190797-0f63229c-de12-4c35-9aa6-0c260d679a55.png" />

#### Attached Term to Resource
<img width="600" src="https://user-images.githubusercontent.com/8689444/184190801-bc9a8bfa-a761-4b39-a11b-e9caadfee6b1.png" />

#### Updated Related Resources List
<img width="600" src="https://user-images.githubusercontent.com/8689444/184190793-e915edad-665a-487d-8afc-19aac4f37e22.png" />

</details>