### PR TITLE
Soft delete expired resources

### DIFF
--- a/app/Console/Commands/GetExpiredResources.php
+++ b/app/Console/Commands/GetExpiredResources.php
@@ -24,6 +24,7 @@ class GetExpiredResources extends Command
                 'url',
                 'expiration_date',
                 'created_at',
+                'deleted_at',
             ]);
 
         if (! count($expiredResources)) {
@@ -37,10 +38,10 @@ class GetExpiredResources extends Command
         }
 
         $this->table(
-            ['Resource Name', 'URL', 'Days Til Expired'],
+            ['Resource Name', 'URL', 'Days Til Expired', 'Trashed'],
             $expiredResources->each
-                ->setAppends(['days_til_expired'])
-                ->makeHidden(['modules', 'created_at', 'expiration_date'])
+                ->setAppends(['days_til_expired', 'is_trashed'])
+                ->makeHidden(['modules', 'created_at', 'expiration_date', 'deleted_at'])
                 ->toArray(),
         );
     }

--- a/app/Console/Commands/GetExpiredResources.php
+++ b/app/Console/Commands/GetExpiredResources.php
@@ -18,6 +18,7 @@ class GetExpiredResources extends Command
             ->orWhere(function ($query) {
                 $query->expiring();
             })
+            ->withTrashed()
             ->with('modules')
             ->get([
                 'name',

--- a/app/Console/Commands/TidyUpExpiredResources.php
+++ b/app/Console/Commands/TidyUpExpiredResources.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Resource;
+use Illuminate\Console\Command;
+
+class TidyUpExpiredResources extends Command
+{
+    private $expiredResourcesCount;
+
+    private $trashedResourcesCount;
+
+    protected $signature = 'resource:tidy {--P|prune} {--preview}';
+
+    protected $description = 'Soft or force delete expired resources. Use the --preview option to view the expired resources report.';
+
+    public function handle()
+    {
+        $expiredResources = Resource::expired()->withTrashed()->get();
+
+        if (! $this->expiredResourcesCount = count($expiredResources)) {
+            return $this->info('No resources to tidy up.');
+        }
+
+        if ($this->option('preview')) {
+            return $this->call('resource:expired');
+        }
+
+        if ($this->pruneExpiredResources()) {
+            $this->withProgressBar($expiredResources, fn($resource) => $resource->forceDelete());
+
+            return $this->info(PHP_EOL . 'Done!');
+        }
+
+        $this->trashedResourcesCount = Resource::expired()->onlyTrashed()->count();
+
+        if ($this->expiredResourcesCount === $this->trashedResourcesCount) {
+            $this->info('No resources to tidy up. There are ' . $this->trashedResourcesCount . ' resources in the trash. To permanently delete them, use the --prune option.');
+
+            return;
+        }
+
+        $this->withProgressBar(Resource::expired()->get(), fn($resource) => $resource->delete());
+
+        $this->info(PHP_EOL . 'Done! To permanently delete resources moved to the trash, use the --prune option.');
+    }
+
+    private function pruneExpiredResources(): bool
+    {
+        return $this->option('prune') && $this->confirm('You are permanently removing ' . $this->expiredResourcesCount . ' expired resources. This action can not be reversed. Continue?');
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -19,11 +19,11 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('inspire')
-        //          ->hourly();
-
         $schedule->command('resource:expired -N')
             ->weeklyOn(Schedule::FRIDAY, '06:00');
+
+        $schedule->command('resource:tidy')
+            ->daily();
     }
 
     /**

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -85,7 +85,7 @@ class Resource extends Model implements Completable
 
     public function scopeExpired($query)
     {
-        return $query->where('expiration_date', '<', now()->toDateTimeString())->withTrashed();
+        return $query->where('expiration_date', '<', now()->toDateTimeString());
     }
 
     public function scopeExpiring($query)

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -8,10 +8,12 @@ use App\Models\Term;
 use App\OperatingSystem;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Resource extends Model implements Completable
 {
     use HasFactory;
+    use SoftDeletes;
 
     public const VIDEO_TYPE = 'video';
     public const COURSE_TYPE = 'course';

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -85,7 +85,7 @@ class Resource extends Model implements Completable
 
     public function scopeExpired($query)
     {
-        return $query->where('expiration_date', '<', now()->toDateTimeString());
+        return $query->where('expiration_date', '<', now()->toDateTimeString())->withTrashed();
     }
 
     public function scopeExpiring($query)
@@ -104,6 +104,11 @@ class Resource extends Model implements Completable
     public function getDaysTilExpiredAttribute()
     {
         return $this->expiration_date->diffForHumans();
+    }
+
+    public function getIsTrashedAttribute()
+    {
+        return $this->deleted_at ? 'Yes' : 'No';
     }
 
     public function isAssignedToAModule()

--- a/database/migrations/2022_10_19_171003_add_deleted_at_column_to_resources_table.php
+++ b/database/migrations/2022_10_19_171003_add_deleted_at_column_to_resources_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('resources', function (Blueprint $table) {
+            $table->softDeletes()->after('updated_at');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('resources', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/tests/Feature/ResourceExpirationTest.php
+++ b/tests/Feature/ResourceExpirationTest.php
@@ -73,15 +73,4 @@ class ResourceExpirationTest extends TestCase
         $this->assertSame('1 day ago', $resourceA->days_til_expired);
         $this->assertSame('2 weeks from now', $resourceB->days_til_expired);
     }
-
-    /** @test */
-    public function soft_deleted_expired_resources_are_returned_with_expired_scope()
-    {
-        $resourceA = Resource::factory()->expired()->create();
-        $resourceB = Resource::factory()->expired()->create();
-
-        $resourceB->delete();
-
-        $this->assertCount(2, Resource::expired()->get());
-    }
 }

--- a/tests/Feature/ResourceExpirationTest.php
+++ b/tests/Feature/ResourceExpirationTest.php
@@ -73,4 +73,15 @@ class ResourceExpirationTest extends TestCase
         $this->assertSame('1 day ago', $resourceA->days_til_expired);
         $this->assertSame('2 weeks from now', $resourceB->days_til_expired);
     }
+
+    /** @test */
+    public function soft_deleted_expired_resources_are_returned_with_expired_scope()
+    {
+        $resourceA = Resource::factory()->expired()->create();
+        $resourceB = Resource::factory()->expired()->create();
+
+        $resourceB->delete();
+
+        $this->assertCount(2, Resource::expired()->get());
+    }
 }


### PR DESCRIPTION
> **Closes #475**

## Summary

**Overview**

This PR adds `SoftDeletes` to the `Resource` model.

It also adds a `resource:tidy` command, scheduled to run daily, that will soft delete any resources that have expired and move them to the trash. 

After reviewing the expired resources report (via Slack or manually), the `resource:tidy` command can be used with the `--prune` option to permanently resources moved to the trash.

Use the `--preview` option with the `resource:tidy` command to see the expired resource report before trashing or permanently deleting any items.

The expired resources report has been updated to specify if an expired resource has been soft deleted or not:

<img width="1390" alt="image" src="https://user-images.githubusercontent.com/8689444/196992316-9e9d44dd-3442-47f2-8920-e5cd35f4b974.png">

**Things to consider:**
- The `--prune` option will remove all expired resources whether they have been moved to the trash or not. Should this only permanently remove trashed items?
