### PR TITLE
Temporarily disable Nova Releases card

### DIFF
--- a/app/Nova/Dashboards/Main.php
+++ b/app/Nova/Dashboards/Main.php
@@ -17,7 +17,7 @@ class Main extends Dashboard
     {
         return [
             new SuggestedResourcesShortcuts(),
-            new LatestRelease(),
+            // new LatestRelease(),
         ];
     }
 }


### PR DESCRIPTION
## Summary

Temporarily disabling this card to see if this resolves an issue with resources not loading inside Nova in production. Resources load fine locally.

<img width="1664" alt="image" src="https://user-images.githubusercontent.com/8689444/197029906-5a2281dc-30bd-4958-ac0c-cc6627246738.png">
