### PR TITLE
Remove Scheduled Command to Soft Delete Expired Resources

### DIFF
--- a/app/Console/Commands/GetExpiredResources.php
+++ b/app/Console/Commands/GetExpiredResources.php
@@ -8,9 +8,19 @@ use Illuminate\Support\Facades\Event;
 
 class GetExpiredResources extends Command
 {
-    protected $signature = 'resource:expired {--N|notify}';
+    protected $signature = 'resource:expired {--N|notify} {--T|trashed}';
 
-    protected $description = 'List or notify Tighten of expired resources.';
+    protected $description = 'List or notify Tighten of expired resources. Used the --trashed option to view resources that have been soft deleted.';
+
+    protected $outputHeaders = [
+        'Resource Name',
+        'URL',
+        'Days Til Expired',
+    ];
+
+    protected $outputAppends = [
+        'days_til_expired',
+    ];
 
     public function handle()
     {
@@ -18,7 +28,9 @@ class GetExpiredResources extends Command
             ->orWhere(function ($query) {
                 $query->expiring();
             })
-            ->withTrashed()
+            ->when($this->option('trashed'), function ($query) {
+                return $query->withTrashed();
+            })
             ->with('modules')
             ->get([
                 'name',
@@ -38,10 +50,15 @@ class GetExpiredResources extends Command
             return;
         }
 
+        if ($this->option('trashed')) {
+            array_push($this->outputHeaders, 'Trashed');
+            array_push($this->outputAppends, 'is_trashed');
+        }
+
         $this->table(
-            ['Resource Name', 'URL', 'Days Til Expired', 'Trashed'],
+            $this->outputHeaders,
             $expiredResources->each
-                ->setAppends(['days_til_expired', 'is_trashed'])
+                ->setAppends($this->outputAppends)
                 ->makeHidden(['modules', 'created_at', 'expiration_date', 'deleted_at'])
                 ->toArray(),
         );

--- a/app/Console/Commands/TidyUpExpiredResources.php
+++ b/app/Console/Commands/TidyUpExpiredResources.php
@@ -13,7 +13,7 @@ class TidyUpExpiredResources extends Command
 
     protected $signature = 'resource:tidy {--P|prune} {--preview}';
 
-    protected $description = 'Soft or force delete expired resources. Use the --preview option to view the expired resources report.';
+    protected $description = 'Soft or force delete expired resources. Use the --preview option to view the full expired resources report.';
 
     public function handle()
     {
@@ -24,7 +24,9 @@ class TidyUpExpiredResources extends Command
         }
 
         if ($this->option('preview')) {
-            return $this->call('resource:expired');
+            return $this->call('resource:expired', [
+                '--trashed' => true,
+            ]);
         }
 
         if ($this->pruneExpiredResources()) {

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -21,9 +21,6 @@ class Kernel extends ConsoleKernel
     {
         $schedule->command('resource:expired -N')
             ->weeklyOn(Schedule::FRIDAY, '06:00');
-
-        $schedule->command('resource:tidy')
-            ->daily();
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR reverts a change made in #500 to automatically soft delete resources at the moment they expire.

Instead, resources will be manually reviewed after the expired resources report is received and then the `resource:tidy` command can be manually run to soft delete any remaining resources that have not been renewed.

This PR also reverts the command line version of the `resource:expired` report to no longer output whether a resource has been moved to the trash or not, unless the `--trashed` option is passed with the command.