### PR TITLE
[Bugfix] Limit Resources Count For Slack Notification

### DIFF
--- a/app/Console/Commands/GetExpiredResources.php
+++ b/app/Console/Commands/GetExpiredResources.php
@@ -32,6 +32,7 @@ class GetExpiredResources extends Command
                 return $query->withTrashed();
             })
             ->with('modules')
+            ->oldest('expiration_date')
             ->get([
                 'name',
                 'url',

--- a/app/Notifications/SendExpiredResources.php
+++ b/app/Notifications/SendExpiredResources.php
@@ -7,6 +7,8 @@ use NathanHeffley\LaravelSlackBlocks\Messages\SlackMessage;
 
 class SendExpiredResources extends Notification
 {
+    const REPORT_LIMIT = 9;
+
     public function __construct(protected $expiredResources)
     {
         //
@@ -23,7 +25,7 @@ class SendExpiredResources extends Notification
             ->from('Onramp', ':onramp:')
             ->content(sprintf('Here is your expired resources report: %s', url('/nova')));
 
-        $this->expiredResources->each(function ($resource) use ($msg) {
+        $this->expiredResources->take(self::REPORT_LIMIT)->each(function ($resource) use ($msg) {
             $msg->attachment(function ($attachment) use ($resource) {
                 if ($resource->isExpiring()) {
                     $hexColor = '#f9c336';
@@ -66,6 +68,28 @@ class SendExpiredResources extends Notification
             });
         });
 
+        if($remainingResources = $this->getRemainingResourcesCount()) {
+            $msg->attachment(function ($attachment) use ($remainingResources) {
+                $attachment->block(function ($block) use ($remainingResources) {
+                    $block
+                        ->type('section')
+                        ->text([
+                            'type' => 'mrkdwn',
+                            'text' => sprintf(
+                                '*<%s|%s>*',
+                                url('/nova'),
+                                "+ $remainingResources more expired or expiring resources",
+                            ),
+                        ]);
+                });
+            });
+        }
+
         return $msg;
+    }
+
+    private function getRemainingResourcesCount(): int
+    {
+        return count($this->expiredResources) - self::REPORT_LIMIT;
     }
 }


### PR DESCRIPTION
This PR will limit the number of resources displayed in the expired resources report sent to slack.

Slack will truncate the number of attachments shown to the first 10 items by default. The report has been updated to show the 9 oldest expired or expiring resources plus a 10th attachment noting how many more expired/expiring resources there are, which also links out to Nova.

<img width="1079" alt="image" src="https://user-images.githubusercontent.com/8689444/201395684-ec1c3dac-d1d7-4a78-a40e-2f4389fa46fc.png">
