### PR TITLE
Renew expiring resources

### DIFF
--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -149,7 +149,7 @@ class Resource extends Model implements Completable
 
     public function isExpiring()
     {
-        return $this->expiration_date->between(
+        return $this->expiration_date?->between(
             now()->toDateTimeString(),
             now()->addDays(15)->toDateTimeString(),
         );

--- a/app/Nova/Filters/ExpiredResource.php
+++ b/app/Nova/Filters/ExpiredResource.php
@@ -13,6 +13,13 @@ class ExpiredResource extends Filter
 
     public function apply(NovaRequest $request, $query, $value)
     {
+        if ($value === '<>') {
+            return $query->whereBetween('expiration_date', [
+                now()->toDateTimeString(),
+                now()->addDays(15)->toDateTimeString(),
+            ]);
+        }
+
         return $query->where('expiration_date', $value, now());
     }
 
@@ -20,6 +27,7 @@ class ExpiredResource extends Filter
     {
         return [
             'Only Expired' => '<',
+            'Only Expiring' => '<>',
             'Only Active' => '>',
         ];
     }

--- a/app/Nova/Resource.php
+++ b/app/Nova/Resource.php
@@ -151,8 +151,10 @@ class Resource extends BaseResource
         return [
             (new Actions\RenewResource())
                 ->canSee(function ($request) {
+                    $shouldRenew = $this->resource->isExpired() || $this->resource->isExpiring();
+
                     return $request instanceof ActionRequest
-                        || ($this->resource->exists && ($this->resource->isExpired() && ! $this->resource->trashed()));
+                        || ($this->resource->exists && ($shouldRenew && ! $this->resource->trashed()));
                 })
                 ->exceptOnIndex(),
         ];


### PR DESCRIPTION
## Summary

This PR allows for renewing expiring resources via Nova.

It also fixes the `canSee` method on the `RenewResource` action so that multiple resources can be renewed at once.