### PR TITLE
Add notes attribute to Resource model

### DIFF
--- a/app/Nova/Resource.php
+++ b/app/Nova/Resource.php
@@ -13,6 +13,7 @@ use Laravel\Nova\Fields\Boolean;
 use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\BelongsToMany;
 use App\Models\Resource as EloquentResource;
+use Laravel\Nova\Fields\Textarea;
 use Laravel\Nova\Http\Requests\ActionRequest;
 
 class Resource extends BaseResource
@@ -99,6 +100,13 @@ class Resource extends BaseResource
                 ->hideFromIndex()
                 ->hideWhenCreating()
                 ->hideWhenUpdating(),
+
+            Textarea::make('Internal Notes', 'notes')
+                ->alwaysShow()
+                ->rows(4)
+                ->withMeta(['extraAttributes' => [
+                    'placeholder' => 'Add notes that are helpful for managing this resource.',
+                ]]),
 
             BelongsToMany::make('Modules'),
 

--- a/database/migrations/2022_11_29_144732_add_notes_column_to_resources_table.php
+++ b/database/migrations/2022_11_29_144732_add_notes_column_to_resources_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('resources', function (Blueprint $table) {
+            $table->text('notes')
+                ->after('language')
+                ->nullable();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('resources', function (Blueprint $table) {
+            $table->dropColumn('notes');
+        });
+    }
+};


### PR DESCRIPTION
## Summary

This PR adds a new `notes` attribute to the `Resource` model. This will allow the team to leave helpful notes for a particular resource that may be useful when renewing them.