### PR TITLE
Fix expired resources report

### DIFF
--- a/app/Console/Commands/GetExpiredResources.php
+++ b/app/Console/Commands/GetExpiredResources.php
@@ -33,13 +33,7 @@ class GetExpiredResources extends Command
             })
             ->with('modules')
             ->oldest('expiration_date')
-            ->get([
-                'name',
-                'url',
-                'expiration_date',
-                'created_at',
-                'deleted_at',
-            ]);
+            ->get();
 
         if (! count($expiredResources)) {
             $this->info('All resources are up to date!');
@@ -60,7 +54,21 @@ class GetExpiredResources extends Command
             $this->outputHeaders,
             $expiredResources->each
                 ->setAppends($this->outputAppends)
-                ->makeHidden(['modules', 'created_at', 'expiration_date', 'deleted_at'])
+                ->makeHidden([
+                    'id',
+                    'modules',
+                    'is_free',
+                    'is_bonus',
+                    'can_expire',
+                    'type',
+                    'language',
+                    'notes',
+                    'os',
+                    'created_at',
+                    'expiration_date',
+                    'updated_at',
+                    'deleted_at',
+                ])
                 ->toArray(),
         );
     }

--- a/app/Notifications/SendExpiredResources.php
+++ b/app/Notifications/SendExpiredResources.php
@@ -90,6 +90,10 @@ class SendExpiredResources extends Notification
 
     private function getRemainingResourcesCount(): int
     {
+        if (count($this->expiredResources) < self::REPORT_LIMIT) {
+            return 0;
+        }
+
         return count($this->expiredResources) - self::REPORT_LIMIT;
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes two bugs on the expired resources report:
- fixes the incorrect `module` count for a resource
- fixes the incorrect remaining resources count at the bottom of the report

| Before | After |
| - | - |
| <img width="767" alt="image" src="https://user-images.githubusercontent.com/8689444/206728158-f6494568-781f-4440-8100-8e097480c3e8.png"> | <img width="702" alt="image" src="https://user-images.githubusercontent.com/8689444/206728326-590f742e-451f-4bc0-8a01-7743ab94830f.png"> |