### PR TITLE
Add methods back to policies

### DIFF
--- a/app/Policies/ModulePolicy.php
+++ b/app/Policies/ModulePolicy.php
@@ -16,28 +16,39 @@ class ModulePolicy
         return $user->isAdmin() ?: null;
     }
 
-    /**
-     * Determine whether the user can view any modules.
-     */
     public function viewAny(User $user): bool
     {
         return true;
     }
 
-    /**
-     * Determine whether the user can view the module.
-     */
     public function view(User $user, Module $module): bool
     {
         return true;
     }
 
-    /**
-     * Determine whether the user can update the module.
-     */
+    public function create(User $user)
+    {
+        //
+    }
+
     public function update(User $user, Module $module): bool
     {
         return false;
+    }
+
+    public function delete(User $user, Module $module)
+    {
+        //
+    }
+
+    public function restore(User $user, Module $module)
+    {
+        //
+    }
+
+    public function forceDelete(User $user, Module $module)
+    {
+        //
     }
 
     public function attachResource(User $user, Module $module, Resource $resource): bool

--- a/app/Policies/ResourcePolicy.php
+++ b/app/Policies/ResourcePolicy.php
@@ -15,11 +15,38 @@ class ResourcePolicy
         return $user->isAtLeastEditor() ?: null;
     }
 
-    /**
-     * Determine whether the user can update the resource.
-     */
-    public function update(User $user, Resource $resource): bool
+    public function viewAny(User $user)
     {
-        return false;
+        //
+    }
+
+    public function view(User $user, User $model)
+    {
+        //
+    }
+
+    public function create(User $user)
+    {
+        //
+    }
+
+    public function update(User $user, Resource $resource)
+    {
+        //
+    }
+
+    public function delete(User $user, Resource $resource)
+    {
+        //
+    }
+
+    public function restore(User $user, Resource $resource)
+    {
+        //
+    }
+
+    public function forceDelete(User $user, Resource $resource)
+    {
+        //
     }
 }

--- a/app/Policies/SkillPolicy.php
+++ b/app/Policies/SkillPolicy.php
@@ -15,19 +15,38 @@ class SkillPolicy
         return $user->isAdmin() ?: null;
     }
 
-    /**
-     * Determine whether the user can view any skills.
-     */
     public function viewAny(User $user): bool
     {
         return $user->isAtLeastEditor();
     }
 
-    /**
-     * Determine whether the user can view the skill.
-     */
-    public function view(User $user, Skill $skill): bool
+    public function view(User $user, Skill $skill)
     {
         return $user->isAtLeastEditor();
+    }
+
+    public function create(User $user)
+    {
+        //
+    }
+
+    public function update(User $user, Skill $skill)
+    {
+        //
+    }
+
+    public function delete(User $user, Skill $skill)
+    {
+        //
+    }
+
+    public function restore(User $user, Skill $skill)
+    {
+        //
+    }
+
+    public function forceDelete(User $user, Skill $skill)
+    {
+        //
     }
 }

--- a/app/Policies/SuggestedResourcePolicy.php
+++ b/app/Policies/SuggestedResourcePolicy.php
@@ -15,57 +15,36 @@ class SuggestedResourcePolicy
         return $user->isAtLeastEditor() ?: null;
     }
 
-    /**
-     * Determine whether the user can view any Suggested resources.
-     */
     public function viewAny(User $user): bool
     {
         return true;
     }
 
-    /**
-     * Determine whether the user can view the Suggested resource.
-     */
     public function view(User $user, SuggestedResource $suggestedResource): bool
     {
         return true;
     }
 
-    /**
-     * Determine whether the user can create Suggested resources.
-     */
     public function create(User $user): bool
     {
         return true;
     }
 
-    /**
-     * Determine whether the user can update the Suggested resource.
-     */
     public function update(User $user, SuggestedResource $suggestedResource): bool
     {
         return $user->id === $suggestedResource->user_id || $user->isAtLeastEditor();
     }
 
-    /**
-     * Determine whether the user can delete the Suggested resource.
-     */
     public function delete(User $user, SuggestedResource $suggestedResource): bool
     {
         return $user->id === $suggestedResource->user_id;
     }
 
-    /**
-     * Determine whether the user can restore the Suggested resource.
-     */
     public function restore(User $user, SuggestedResource $suggestedResource): bool
     {
         //
     }
 
-    /**
-     * Determine whether the user can permanently delete the Suggested resource.
-     */
     public function forceDelete(User $user, SuggestedResource $suggestedResource): bool
     {
         //

--- a/app/Policies/TermPolicy.php
+++ b/app/Policies/TermPolicy.php
@@ -15,11 +15,38 @@ class TermPolicy
         return $user->isAtLeastEditor() ?: null;
     }
 
-    /**
-     * Determine whether the user can update the term.
-     */
-    public function update(User $user, Term $term): bool
+    public function viewAny(User $user)
     {
-        return false;
+        //
+    }
+
+    public function view(User $user, Term $term)
+    {
+        //
+    }
+
+    public function create(User $user)
+    {
+        //
+    }
+
+    public function update(User $user, Term $term)
+    {
+        //
+    }
+
+    public function delete(User $user, Term $term)
+    {
+        //
+    }
+
+    public function restore(User $user, Term $term)
+    {
+        //
+    }
+
+    public function forceDelete(User $user, Term $term)
+    {
+        //
     }
 }

--- a/app/Policies/TrackPolicy.php
+++ b/app/Policies/TrackPolicy.php
@@ -15,27 +15,33 @@ class TrackPolicy
         return $user->isAdmin() ?: null;
     }
 
-    /**
-     * Determine whether the user can view any tracks.
-     */
     public function viewAny(User $user): bool
     {
         return $user->isAtLeastEditor();
     }
 
-    /**
-     * Determine whether the user can view the track.
-     */
     public function view(User $user, Track $track): bool
     {
         return $user->isAtLeastEditor();
     }
 
-    /**
-     * Determine whether the user can update the track.
-     */
-    public function update(User $user, Track $track): bool
+    public function update(User $user, Track $track)
     {
-        return false;
+        //
+    }
+
+    public function delete(User $user, Track $track)
+    {
+        //
+    }
+
+    public function restore(User $user, Track $track)
+    {
+        //
+    }
+
+    public function forceDelete(User $user, Track $track)
+    {
+        //
     }
 }

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -14,11 +14,38 @@ class UserPolicy
         return $user->isAdmin() ?: null;
     }
 
-    /**
-     * Determine whether the user can update the model.
-     */
-    public function update(User $user, User $model): bool
+    public function viewAny(User $user)
     {
-        return false;
+        //
+    }
+
+    public function view(User $user, User $model)
+    {
+        //
+    }
+
+    public function create(User $user)
+    {
+        //
+    }
+
+    public function update(User $user, User $model)
+    {
+        //
+    }
+
+    public function delete(User $user, User $model)
+    {
+        //
+    }
+
+    public function restore(User $user, User $model)
+    {
+        //
+    }
+
+    public function forceDelete(User $user, User $model)
+    {
+        //
     }
 }


### PR DESCRIPTION
## Summary

This PR replaces policy methods removed in #554 so that the correct authorizations are in place for Nova resources.