### PR TITLE
Fix local installation

### DIFF
--- a/app/Console/Commands/GenerateSeedsFromDatabase.php
+++ b/app/Console/Commands/GenerateSeedsFromDatabase.php
@@ -20,19 +20,14 @@ class GenerateSeedsFromDatabase extends Command
 
     protected $description = 'Sync core data and generate new seed files for local development.';
 
-    public function __construct()
+    public function handle(): int
     {
-        parent::__construct();
-
         if (app()->environment() === 'local') {
             dispatch(new CreateTunnel);
         }
 
         $this->dirPath = config('seeder.directory', 'database/json');
-    }
 
-    public function handle(): int
-    {
         $methods = collect([
             'Modules' => 'syncModules',
             'Resources' => 'syncResources',


### PR DESCRIPTION
This PR fixes the installation of onramp locally by moving the code from a command constructor.

![image](https://github.com/tighten/onramp/assets/19756164/42f80ce4-6da2-4577-83c1-209312b63d80)


When running artisan, the code on all commands `__construct` method is executed, so if we have a failure there the artisan command will also fail.