### PR TITLE
Fixes markdown rendering on email digests

### DIFF
--- a/resources/views/emails/rejected-resource.blade.php
+++ b/resources/views/emails/rejected-resource.blade.php
@@ -1,15 +1,15 @@
 <x-mail::message>
-	Hello {{ $user->name }},
+Hello {{ $user->name }},
 
-	The resource you suggested on [Onramp]({{ route('welcome', ['locale' => 'en']) }}) has been rejected by one of our reviewers:
+The resource you suggested on [Onramp]({{ route('welcome', ['locale' => 'en']) }}) has been rejected by one of our reviewers:
 
-	<x-mail::panel>
-		{{ $resource->name }}<br>
-		[Resource URL]({{ $resource->url }})
-		###### *Submitted on {{ $resource->created_at->format('d-m-Y') }}*
+<x-mail::panel>
+{{ $resource->name }}<br>
+[Resource URL]({{ $resource->url }})
+###### *Submitted on {{ $resource->created_at->format('d-m-Y') }}*
 
-		**{{ $resource->rejected_reason }}**
-	</x-mail::panel>
+**{{ $resource->rejected_reason }}**
+</x-mail::panel>
 
-	We thank you for your contribution and encourage you to submit new resources that may be useful to the community.
+We thank you for your contribution and encourage you to submit new resources that may be useful to the community.
 </x-mail::message>

--- a/resources/views/emails/resource-digest.blade.php
+++ b/resources/views/emails/resource-digest.blade.php
@@ -13,7 +13,10 @@ Added on {{ \Carbon\Carbon::parse($resource['created_at'])->format('F j, Y') }}
 
 ### Your friends at {{ config('app.name') }}
 
-<x-mail::button :url="$unsubscribeUrl">
-Unsubscribe
-</x-mail::button>
+
+<x-mail::subcopy>
+You are receiving this email because you subscribed at [{{ config('app.name') }}]({{ config('app.url') }}).<br />
+[Unsubscribe]({{ $unsubscribeUrl }})
+</x-mail::subcopy>
+
 </x-mail::message>

--- a/resources/views/emails/resource-digest.blade.php
+++ b/resources/views/emails/resource-digest.blade.php
@@ -1,19 +1,19 @@
 <x-mail::message>
-	# Here are the latest resources:
+# Here are the latest resources:
 
-	<x-mail::panel>
-		@foreach ($resources as $resource)
-		- [{{ $resource['name'] }}]({{ $resource['url'] }})
-		Added on {{ \Carbon\Carbon::parse($resource['created_at'])->format('F j, Y') }}
+<x-mail::panel>
+@foreach ($resources as $resource)
+- [{{ $resource['name'] }}]({{ $resource['url'] }}) <br />
+Added on {{ \Carbon\Carbon::parse($resource['created_at'])->format('F j, Y') }}
 
-		@endforeach
-	</x-mail::panel>
+@endforeach
+</x-mail::panel>
 
-	### Happy Coding!
+### Happy Coding!
 
-	### Your friends at {{ config('app.name') }}
+### Your friends at {{ config('app.name') }}
 
-	<x-mail::button :url="$unsubscribeUrl">
-		Unsubscribe
-	</x-mail::button>
+<x-mail::button :url="$unsubscribeUrl">
+Unsubscribe
+</x-mail::button>
 </x-mail::message>

--- a/resources/views/emails/resource-digest.blade.php
+++ b/resources/views/emails/resource-digest.blade.php
@@ -11,7 +11,7 @@ Added on {{ \Carbon\Carbon::parse($resource['created_at'])->format('F j, Y') }}
 
 ### Happy Coding!
 
-### Your friends at {{ config('app.name') }}
+### Your friends at Tighten
 
 
 <x-mail::subcopy>


### PR DESCRIPTION
## Highlights
- removes all white spaces from email templates that opt for markdown rendering
- tweaks the unsub look and feels

### Notes
Feels a lil odd to say `Onramp` so much in the email, but also kind of like it, what ya think?

<details><summary>Email Screenshots</summary>
<p>
<img width="587" alt="image" src="https://github.com/user-attachments/assets/d5b0b410-bdaf-49fe-9fa0-559c6c98a0ea">



</p>
</details> 