### PR TITLE
Fixes auth expiration

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -10,10 +10,8 @@ class Authenticate extends Middleware
     /**
      * Get the path the user should be redirected to when they are not authenticated.
      */
-    protected function redirectTo(Request $request): string
+    protected function redirectTo(Request $request): ?string
     {
-        if (! $request->expectsJson()) {
-            return route_wlocale('login');
-        }
+        return $request->expectsJson() ? null : route_wlocale('login');
     }
 }

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -13,11 +13,12 @@ class AuthTest extends TestCase
     /** @test */
     public function user_can_log_in(): void
     {
-        $this->be($user = User::factory()->create());
+        $user = User::factory()->create();
 
         $response = $this->post('/en/login', [
             'email' => $user->email,
-            'password' => $user->password,
+            'password' => 'password',
+            'remember' => true,
         ]);
 
         $response->assertRedirect('/en/modules');


### PR DESCRIPTION
Does the following:
- Tweaks the `Authenticate` return type ensuring when ajax request are performed, we handle them without a type error
- Changes the authentication test to pass the un-hashed pass